### PR TITLE
Feature: `tree-sitter-sql` の CST に似た構造を持つ CST への変換機能

### DIFF
--- a/crates/postgresql-cst-parser/src/tree_sitter.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter.rs
@@ -1,8 +1,8 @@
 #[cfg(test)]
 mod assert_util;
-mod transform;
 
-pub use transform::transform_cst;
+mod convert;
+pub use convert::convert_cst;
 
 use std::{collections::HashMap, fmt::Display, rc::Rc};
 

--- a/crates/postgresql-cst-parser/src/tree_sitter.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter.rs
@@ -1,4 +1,7 @@
+#[cfg(test)]
+mod assert_util;
 mod transform;
+
 pub use transform::transform_cst;
 
 use std::{collections::HashMap, fmt::Display, rc::Rc};

--- a/crates/postgresql-cst-parser/src/tree_sitter.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter.rs
@@ -1,4 +1,5 @@
 mod transform;
+pub use transform::transform_cst;
 
 use std::{collections::HashMap, fmt::Display, rc::Rc};
 

--- a/crates/postgresql-cst-parser/src/tree_sitter.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter.rs
@@ -1,3 +1,5 @@
+mod transform;
+
 use std::{collections::HashMap, fmt::Display, rc::Rc};
 
 use cstree::text::TextRange;

--- a/crates/postgresql-cst-parser/src/tree_sitter/assert_util.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter/assert_util.rs
@@ -36,7 +36,7 @@ pub fn assert_node_count(root: &ResolvedNode, kind: SyntaxKind, expected_count: 
 }
 
 /// Asserts that there are no directly nested nodes of the specified `SyntaxKind`.
-/// In other words, a node of `kind` cannnot have another `kind` node as its immediate child.
+/// In other words, a node of `kind` cannot have another `kind` node as its immediate child.
 pub fn assert_no_direct_nested_kind(root: &ResolvedNode, kind: SyntaxKind) {
     fn visit(node: &ResolvedNode, kind: SyntaxKind) {
         if node.kind() == kind {

--- a/crates/postgresql-cst-parser/src/tree_sitter/assert_util.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter/assert_util.rs
@@ -1,0 +1,128 @@
+use crate::{syntax_kind::SyntaxKind, ResolvedNode};
+
+pub fn assert_exists(root: &ResolvedNode, kind: SyntaxKind) {
+    let exists = root.descendants().any(|node| node.kind() == kind);
+    if !exists {
+        panic!(
+            "Expected no nodes of kind {:?}, but at least one was found.",
+            kind
+        );
+    }
+}
+
+pub fn assert_not_exists(root: &ResolvedNode, kind: SyntaxKind) {
+    let exists = root.descendants().any(|node| node.kind() == kind);
+    if exists {
+        panic!(
+            "Expected no nodes of kind {:?}, but at least one was found.",
+            kind
+        );
+    }
+}
+
+pub fn assert_node_count(root: &ResolvedNode, kind: SyntaxKind, expected_count: usize) {
+    let actual_count = root
+        .descendants()
+        .filter(|node| node.kind() == kind)
+        .count();
+    assert_eq!(
+        actual_count, expected_count,
+        "Expected {} nodes of kind {:?}, but found {}.",
+        expected_count, kind, actual_count
+    )
+}
+
+pub fn assert_no_direct_nested_kind(root: &ResolvedNode, kind: SyntaxKind) {
+    fn visit(node: &ResolvedNode, kind: SyntaxKind) {
+        if node.kind() == kind {
+            for child in node.children() {
+                if child.kind() == kind {
+                    panic!(
+                        "Found a `{:?}` node that directly contains another {:?} node as a child.",
+                        node, kind
+                    );
+                }
+            }
+        }
+
+        for child in node.children() {
+            visit(&child, kind);
+        }
+    }
+    visit(root, kind);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cst;
+
+    #[test]
+    fn test_assert_exists_passes() {
+        let input = "select a, b, c from t;";
+        let root = cst::parse(input).unwrap();
+        assert_exists(&root, SyntaxKind::SelectStmt);
+        assert_exists(&root, SyntaxKind::from_clause);
+    }
+
+    #[test]
+    #[should_panic(expected = "Expected no nodes of kind InsertStmt, but at least one was found.")]
+    fn test_assert_exists_fails() {
+        let input = "select a, b, c from t;";
+        let root = cst::parse(input).unwrap();
+        assert_exists(&root, SyntaxKind::InsertStmt);
+    }
+
+    #[test]
+    fn test_assert_not_exists_passes() {
+        let input = "select a, b, c from t;";
+        let root = cst::parse(input).unwrap();
+        assert_not_exists(&root, SyntaxKind::InsertStmt);
+        assert_not_exists(&root, SyntaxKind::with_clause);
+    }
+
+    #[test]
+    #[should_panic(expected = "Expected no nodes of kind from_clause, but at least one was found.")]
+    fn test_assert_not_exists_fails() {
+        let input = "select a, b, c from t;";
+        let root = cst::parse(input).unwrap();
+        assert_not_exists(&root, SyntaxKind::from_clause);
+    }
+    #[test]
+    fn test_assert_node_count_passes() {
+        let input = "select a, b, c from t;";
+        let root = cst::parse(input).unwrap();
+
+        assert_node_count(&root, SyntaxKind::SelectStmt, 1);
+        assert_node_count(&root, SyntaxKind::target_el, 3);
+        assert_node_count(&root, SyntaxKind::from_clause, 1);
+        assert_node_count(&root, SyntaxKind::DeleteStmt, 0);
+    }
+    #[test]
+    #[should_panic(expected = "Expected 0 nodes of kind SelectStmt, but found 1.")]
+    fn test_assert_node_count_fails() {
+        let input = "select a, b, c from t;";
+        let root = cst::parse(input).unwrap();
+
+        assert_node_count(&root, SyntaxKind::SelectStmt, 0);
+    }
+
+    #[test]
+    fn test_no_direct_nested_kind_passes() {
+        let input = "select a;";
+        let root = cst::parse(input).unwrap();
+
+        assert_no_direct_nested_kind(&root, SyntaxKind::target_list);
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "Found a `target_list@7..12` node that directly contains another target_list node as a child."
+    )]
+    fn test_no_direct_nested_kind_fails() {
+        let input = "select a,b,c;";
+        let root = cst::parse(input).unwrap();
+
+        assert_no_direct_nested_kind(&root, SyntaxKind::target_list);
+    }
+}

--- a/crates/postgresql-cst-parser/src/tree_sitter/assert_util.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter/assert_util.rs
@@ -36,23 +36,18 @@ pub fn assert_node_count(root: &ResolvedNode, kind: SyntaxKind, expected_count: 
 /// Asserts that there are no directly nested nodes of the specified `SyntaxKind`.
 /// In other words, a node of `kind` cannot have another `kind` node as its immediate child.
 pub fn assert_no_direct_nested_kind(root: &ResolvedNode, kind: SyntaxKind) {
-    fn visit(node: &ResolvedNode, kind: SyntaxKind) {
-        if node.kind() == kind {
-            for child in node.children() {
-                if child.kind() == kind {
-                    panic!(
-                        "Found a `{:?}` node that directly contains another {:?} node as a child.",
-                        node, kind
-                    );
-                }
-            }
-        }
+    let target_nodes = root.descendants().filter(|node| node.kind() == kind);
 
-        for child in node.children() {
-            visit(&child, kind);
+    for node in target_nodes {
+        if let Some(parent) = node.parent() {
+            assert!(
+                !(node.kind() == kind && parent.kind() == kind),
+                "Found a `{:?}` node that directly contains another {:?} node as a child.",
+                parent,
+                kind
+            )
         }
     }
-    visit(root, kind);
 }
 
 #[cfg(test)]

--- a/crates/postgresql-cst-parser/src/tree_sitter/assert_util.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter/assert_util.rs
@@ -1,15 +1,17 @@
 use crate::{syntax_kind::SyntaxKind, ResolvedNode};
 
+/// Asserts that there is at least one node of the specified `SyntaxKind` in the given syntax tree.
 pub fn assert_exists(root: &ResolvedNode, kind: SyntaxKind) {
     let exists = root.descendants().any(|node| node.kind() == kind);
     if !exists {
         panic!(
-            "Expected no nodes of kind {:?}, but at least one was found.",
+            "Expected at least one node of kind {:?}, but none was found.",
             kind
         );
     }
 }
 
+/// Asserts that there are no nodes of the specified `SyntaxKind` in the given syntax tree.
 pub fn assert_not_exists(root: &ResolvedNode, kind: SyntaxKind) {
     let exists = root.descendants().any(|node| node.kind() == kind);
     if exists {
@@ -20,6 +22,7 @@ pub fn assert_not_exists(root: &ResolvedNode, kind: SyntaxKind) {
     }
 }
 
+/// Asserts that the exact number of nodes of the specified `SyntaxKind` matches the given count.
 pub fn assert_node_count(root: &ResolvedNode, kind: SyntaxKind, expected_count: usize) {
     let actual_count = root
         .descendants()
@@ -32,6 +35,8 @@ pub fn assert_node_count(root: &ResolvedNode, kind: SyntaxKind, expected_count: 
     )
 }
 
+/// Asserts that there are no directly nested nodes of the specified `SyntaxKind`.
+/// In other words, a node of `kind` cannnot have another `kind` node as its immediate child.
 pub fn assert_no_direct_nested_kind(root: &ResolvedNode, kind: SyntaxKind) {
     fn visit(node: &ResolvedNode, kind: SyntaxKind) {
         if node.kind() == kind {
@@ -66,7 +71,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Expected no nodes of kind InsertStmt, but at least one was found.")]
+    #[should_panic(expected = "Expected at least one node of kind InsertStmt, but none was found.")]
     fn test_assert_exists_fails() {
         let input = "select a, b, c from t;";
         let root = cst::parse(input).unwrap();

--- a/crates/postgresql-cst-parser/src/tree_sitter/assert_util.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter/assert_util.rs
@@ -3,23 +3,21 @@ use crate::{syntax_kind::SyntaxKind, ResolvedNode};
 /// Asserts that there is at least one node of the specified `SyntaxKind` in the given syntax tree.
 pub fn assert_exists(root: &ResolvedNode, kind: SyntaxKind) {
     let exists = root.descendants().any(|node| node.kind() == kind);
-    if !exists {
-        panic!(
-            "Expected at least one node of kind {:?}, but none was found.",
-            kind
-        );
-    }
+    assert!(
+        exists,
+        "Expected at least one node of kind {:?}, but none was found.",
+        kind
+    )
 }
 
 /// Asserts that there are no nodes of the specified `SyntaxKind` in the given syntax tree.
 pub fn assert_not_exists(root: &ResolvedNode, kind: SyntaxKind) {
     let exists = root.descendants().any(|node| node.kind() == kind);
-    if exists {
-        panic!(
-            "Expected no nodes of kind {:?}, but at least one was found.",
-            kind
-        );
-    }
+    assert!(
+        !exists,
+        "Expected no nodes of kind {:?}, but at least one was found.",
+        kind
+    )
 }
 
 /// Asserts that the exact number of nodes of the specified `SyntaxKind` matches the given count.

--- a/crates/postgresql-cst-parser/src/tree_sitter/convert.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter/convert.rs
@@ -2,6 +2,7 @@ use cstree::{build::GreenNodeBuilder, syntax::SyntaxNode};
 
 use crate::{syntax_kind::SyntaxKind, PostgreSQLSyntax, ResolvedNode};
 
+/// Converts the given CST into a node structure and hierarchy that closely matches what `tree-sitter-sql` produces.
 pub fn convert_cst(root: &ResolvedNode) -> ResolvedNode {
     let mut builder = GreenNodeBuilder::new();
 

--- a/crates/postgresql-cst-parser/src/tree_sitter/transform.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter/transform.rs
@@ -31,7 +31,9 @@ fn walk_and_build(
         match child {
             NodeOrToken::Node(n) => {
                 match n.kind() {
-                    child_kind @ SyntaxKind::target_list => {
+                    child_kind @ (SyntaxKind::stmtmulti
+                    | SyntaxKind::target_list
+                    | SyntaxKind::from_list) => {
                         if parent_kind == child_kind {
                             // [Flatten]
                             //
@@ -144,7 +146,24 @@ FROM
             assert_node_count(&root, SyntaxKind::target_list, 3);
 
             assert_no_direct_nested_kind(&new_root, SyntaxKind::target_list);
-            assert_node_count(&new_root, SyntaxKind::target_list, 1);
+        }
+
+        #[test]
+        fn no_nested_stmtmulti() {
+            let input = "select a,b,c;\nselect d,e from t;";
+            let root = cst::parse(input).unwrap();
+            let new_root = transform_cst(&root);
+
+            assert_no_direct_nested_kind(&new_root, SyntaxKind::stmtmulti);
+        }
+
+        #[test]
+        fn no_nested_from_list() {
+            let input = "select * from t1, t2;";
+            let root = cst::parse(input).unwrap();
+            let new_root = transform_cst(&root);
+
+            assert_no_direct_nested_kind(&new_root, SyntaxKind::from_list);
         }
     }
 

--- a/crates/postgresql-cst-parser/src/tree_sitter/transform.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter/transform.rs
@@ -99,6 +99,8 @@ FROM
         let root = cst::parse(input).unwrap();
         let new_root = transform_cst(&root);
 
+        //  Assert that the CST is not broken by the conversion.
+        //  format!("{ResolvedNode}") returns original input str.
         assert_eq!(format!("{root}"), format!("{new_root}"));
     }
 

--- a/crates/postgresql-cst-parser/src/tree_sitter/transform.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter/transform.rs
@@ -4,8 +4,8 @@ use crate::{syntax_kind::SyntaxKind, PostgreSQLSyntax, ResolvedNode};
 
 /// Function call flow:
 ///  transform_cst (public)
-///    +- walk_and_build 
-///      +- flatten 
+///    +- walk_and_build
+///      +- flatten
 ///      +- remove_exact <- 消した後どうやって復帰するか、簡単に復帰できるかは未検討
 
 pub fn transform_cst(root: &ResolvedNode) -> ResolvedNode {
@@ -46,8 +46,13 @@ fn walk_and_build(
                 //     tree_sitter::is_flattern_all では列挙してるからそれに従おう
 
                 match n.kind() {
-                    // TODO:
+                    // TODO: flatten
                     // SyntaxKind::target_list=> {},
+                    
+                    // removal
+                    SyntaxKind::opt_target_list => {
+                        walk_and_build(builder, n);
+                    }
 
                     // all pattern
                     kind @ _ => {
@@ -78,7 +83,7 @@ mod tests {
     use crate::{cst, tree_sitter::transform::transform_cst};
 
     #[test]
-    fn compare_new_tree_and_old_tree() {
+    fn restored_texts_are_equal() {
         let input = r#"
 SELECT
 	1 as X
@@ -94,6 +99,124 @@ FROM
 
         // dbg!(&root);
         // dbg!(&new_root);
-        assert_eq!(format!("{root}"), format!("{new_root}")); // 書き換え前なので、同一のTreeになることを確認
+        assert_eq!(format!("{root}"), format!("{new_root}"));
+    }
+    mod removal {
+        use crate::{cst, tree_sitter::transform::transform_cst};
+
+        #[test]
+        fn opt_target_list() {
+            let input = "select a,b,c;";
+            let root = cst::parse(input).unwrap();
+            let new_root = transform_cst(&root);
+
+            let printed_new_tree = format!("{new_root:#?}");
+            assert!(!printed_new_tree.contains("opt_target_list"))
+        }
+    }
+    
+    mod flatten {
+        use crate::{cst, tree_sitter::transform::transform_cst};
+
+        #[test]
+        fn target_list() {
+            let input = "select a,b,c;";
+            let root = cst::parse(input).unwrap();
+            let new_root = transform_cst(&root);
+            
+            let actual = format!("{new_root:#?}");
+            let expected = r#"Root@0..13
+  parse_toplevel@0..13
+    stmtmulti@0..13
+      stmtmulti@0..12
+        toplevel_stmt@0..12
+          stmt@0..12
+            SelectStmt@0..12
+              select_no_parens@0..12
+                simple_select@0..12
+                  SELECT@0..6 "select"
+                  Whitespace@6..7 " "
+                  target_list@7..12
+                    target_el@7..8
+                      a_expr@7..8
+                        c_expr@7..8
+                          columnref@7..8
+                            ColId@7..8
+                              IDENT@7..8 "a"
+                    Comma@8..9 ","
+                    target_el@9..10
+                      a_expr@9..10
+                        c_expr@9..10
+                          columnref@9..10
+                            ColId@9..10
+                              IDENT@9..10 "b"
+                    Comma@10..11 ","
+                    target_el@11..12
+                      a_expr@11..12
+                        c_expr@11..12
+                          columnref@11..12
+                            ColId@11..12
+                              IDENT@11..12 "c"
+      Semicolon@12..13 ";"
+"#;
+
+            assert_eq!(actual, expected);
+        }
+        
+    }
+}
+
+#[cfg(test)]
+mod learning_tests {
+    use crate::cst;
+
+    #[test]
+    fn simple_format() {
+        let input = "select a;";
+        let root = cst::parse(input).unwrap();
+
+        let actual = format!("{root}");
+        let expected = "select a;";
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn debug_formmat() {
+        let input = "select a;";
+        let root = cst::parse(input).unwrap();
+
+        let actual = format!("{root:?}");
+        let expected = "Root@0..9";
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn pretty_debug_formmat() {
+        let input = "select a;";
+        let root = cst::parse(input).unwrap();
+
+        let actual = format!("{root:#?}");
+        let expected = r#"Root@0..9
+  parse_toplevel@0..9
+    stmtmulti@0..9
+      stmtmulti@0..8
+        toplevel_stmt@0..8
+          stmt@0..8
+            SelectStmt@0..8
+              select_no_parens@0..8
+                simple_select@0..8
+                  SELECT@0..6 "select"
+                  Whitespace@6..7 " "
+                  opt_target_list@7..8
+                    target_list@7..8
+                      target_el@7..8
+                        a_expr@7..8
+                          c_expr@7..8
+                            columnref@7..8
+                              ColId@7..8
+                                IDENT@7..8 "a"
+      Semicolon@8..9 ";"
+"#;
+        assert_eq!(actual, expected);
     }
 }

--- a/crates/postgresql-cst-parser/src/tree_sitter/transform.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter/transform.rs
@@ -68,7 +68,7 @@ SELECT
 FROM
 	A
 ,	B"#;
-        dbg!(input);
+        // dbg!(input);
         let root = cst::parse(input).unwrap();
 
         let mut tree_builder = TreeBuilder::new();
@@ -79,6 +79,7 @@ FROM
 
         dbg!(&root);
         dbg!(&new_root);
+        assert_eq!(format!("{root}"), format!("{new_root}"));
 
         Ok(())
     }

--- a/crates/postgresql-cst-parser/src/tree_sitter/transform.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter/transform.rs
@@ -2,8 +2,15 @@ use cstree::{build::GreenNodeBuilder, syntax::SyntaxNode};
 
 use crate::{syntax_kind::SyntaxKind, PostgreSQLSyntax, ResolvedNode};
 
+/// Function call flow:
+///  transform_cst (public)
+///    +- walk_and_build 
+///      +- flatten 
+///      +- remove_exact <- 消した後どうやって復帰するか、簡単に復帰できるかは未検討
+
 pub fn transform_cst(root: &ResolvedNode) -> ResolvedNode {
     let mut builder = GreenNodeBuilder::new();
+
     builder.start_node(SyntaxKind::Root);
     walk_and_build(&mut builder, root);
     builder.finish_node();
@@ -11,16 +18,17 @@ pub fn transform_cst(root: &ResolvedNode) -> ResolvedNode {
     let (tree, cache) = builder.finish();
     let new_root =
         SyntaxNode::new_root_with_resolver(tree, cache.unwrap().into_interner().unwrap());
+
     new_root
 }
 
-/// CST を走査し、いくつかのNodeを書き換える
+/// CST を走査し、いくつかの Node を書き換える
 /// e.g. flatten list node, remove option node
 fn walk_and_build(
     builder: &mut GreenNodeBuilder<'static, 'static, PostgreSQLSyntax>,
     node: &ResolvedNode,
 ) {
-    // for now, just walk
+    //TODO: transform cst. but for now, just walk
     use cstree::util::NodeOrToken;
     let mut children = node.children_with_tokens();
 
@@ -70,7 +78,7 @@ mod tests {
     use crate::{cst, tree_sitter::transform::transform_cst};
 
     #[test]
-    fn test() {
+    fn compare_new_tree_and_old_tree() {
         let input = r#"
 SELECT
 	1 as X

--- a/crates/postgresql-cst-parser/src/tree_sitter/transform.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter/transform.rs
@@ -1,86 +1,76 @@
-use cstree::{build::GreenNodeBuilder, green::GreenNode, interning::Interner, Syntax};
+use cstree::{build::GreenNodeBuilder, syntax::SyntaxNode};
 
 use crate::{syntax_kind::SyntaxKind, PostgreSQLSyntax, ResolvedNode};
 
-// TODO(refactor): TreeBuilderにしなくても、(ResolvedNode -> ResolvedNode) な純粋関数でいいかも
-struct TreeBuilder {
-    // lexer がいらない
-    builder: GreenNodeBuilder<'static, 'static, PostgreSQLSyntax>,
+pub fn transform_cst(root: &ResolvedNode) -> ResolvedNode {
+    let mut builder = GreenNodeBuilder::new();
+    builder.start_node(SyntaxKind::Root);
+    walk_and_build(&mut builder, root);
+    builder.finish_node();
+
+    let (tree, cache) = builder.finish();
+    let new_root =
+        SyntaxNode::new_root_with_resolver(tree, cache.unwrap().into_interner().unwrap());
+    new_root
 }
 
-impl TreeBuilder {
-    pub fn new() -> Self {
-        Self {
-            builder: GreenNodeBuilder::new(),
-        }
-    }
+/// CST を走査し、いくつかのNodeを書き換える
+/// e.g. flatten list node, remove option node
+fn walk_and_build(
+    builder: &mut GreenNodeBuilder<'static, 'static, PostgreSQLSyntax>,
+    node: &ResolvedNode,
+) {
+    // for now, just walk
+    use cstree::util::NodeOrToken;
+    let mut children = node.children_with_tokens();
 
-    pub fn build(&mut self, node: &ResolvedNode) -> Result<(), String> {
-        self.builder.start_node(SyntaxKind::Root);
-        self.walk_and_build(node)?;
-        self.builder.finish_node();
-        Ok(())
-    }
-
-    fn walk_and_build(&mut self, node: &ResolvedNode) -> Result<(), String> {
-        // for now, just walk
-        use cstree::util::NodeOrToken;
-        let mut children = node.children_with_tokens();
-
-        while let Some(child) = children.next() {
-            match child {
-                NodeOrToken::Node(n) => {
-                    // for debug
-                    if format!("{}", n.kind()).starts_with("opt_") {
-                        println!("Node  (kind: {})", n.kind());
-                    }
-
-                    // thinking: opt_* でマッチして処理するか、match で全列挙するか？
-                    //     node.kind って Enum か Raw Value しかないから、前方一致で分岐させるのは厳しいか
-                    //     format!("{}", n.kind()).starts_with("opt_") とはできるけど、これってオーバーヘッドないのか？
-                    //     tree_sitter::is_flattern_all では列挙してるからそれに従おう
-
-                    match n.kind() {
-                        // TODO:
-                        // SyntaxKind::target_list=> {},
-
-                        // all pattern
-                        kind @ _ => {
-                            self.builder.start_node(kind);
-
-                            self.walk_and_build(n)?;
-
-                            self.builder.finish_node();
-                        }
-                    }
+    while let Some(child) = children.next() {
+        match child {
+            NodeOrToken::Node(n) => {
+                // for debug
+                if format!("{}", n.kind()).starts_with("opt_") {
+                    println!("Node  (kind: {})", n.kind());
                 }
-                NodeOrToken::Token(t) => {
-                    // for debug
-                    // println!(
-                    //     "Token (kind: {}, text: \"{}\")",
-                    //     t.kind(),
-                    //     t.text().escape_debug()
-                    // );
 
-                    self.builder.token(t.kind(), t.text());
+                // thinking: opt_* でマッチして処理するか、match で全列挙するか？
+                //     node.kind って Enum か Raw Value しかないから、前方一致で分岐させるのは厳しいか
+                //     format!("{}", n.kind()).starts_with("opt_") とはできるけど、これってオーバーヘッドないのか？
+                //     tree_sitter::is_flattern_all では列挙してるからそれに従おう
+
+                match n.kind() {
+                    // TODO:
+                    // SyntaxKind::target_list=> {},
+
+                    // all pattern
+                    kind @ _ => {
+                        builder.start_node(kind);
+
+                        walk_and_build(builder, n);
+
+                        builder.finish_node();
+                    }
                 }
             }
-        }
-        Ok(())
-    }
+            NodeOrToken::Token(t) => {
+                // for debug
+                // println!(
+                //     "Token (kind: {}, text: \"{}\")",
+                //     t.kind(),
+                //     t.text().escape_debug()
+                // );
 
-    pub fn finish(self) -> (GreenNode, impl Interner) {
-        let (tree, cache) = self.builder.finish();
-        (tree, cache.unwrap().into_interner().unwrap())
+                builder.token(t.kind(), t.text());
+            }
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::{cst, tree_sitter::transform::TreeBuilder, SyntaxNode};
+    use crate::{cst, tree_sitter::transform::transform_cst};
 
     #[test]
-    fn test() -> Result<(), String> {
+    fn test() {
         let input = r#"
 SELECT
 	1 as X
@@ -92,16 +82,10 @@ FROM
         // dbg!(input);
         let root = cst::parse(input).unwrap();
 
-        let mut tree_builder = TreeBuilder::new();
-        tree_builder.build(&root)?;
-
-        let (tree, interner) = tree_builder.finish();
-        let new_root = SyntaxNode::new_root_with_resolver(tree, interner);
+        let new_root = transform_cst(&root);
 
         // dbg!(&root);
         // dbg!(&new_root);
-        assert_eq!(format!("{root}"), format!("{new_root}"));
-
-        Ok(())
+        assert_eq!(format!("{root}"), format!("{new_root}")); // 書き換え前なので、同一のTreeになることを確認
     }
 }

--- a/crates/postgresql-cst-parser/src/tree_sitter/transform.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter/transform.rs
@@ -1,0 +1,85 @@
+use cstree::{build::GreenNodeBuilder, green::GreenNode, interning::Interner};
+
+use crate::{syntax_kind::SyntaxKind, PostgreSQLSyntax, ResolvedNode};
+
+struct TreeBuilder {
+    // lexer がいらない
+    builder: GreenNodeBuilder<'static, 'static, PostgreSQLSyntax>,
+}
+
+impl TreeBuilder {
+    pub fn new() -> Self {
+        Self {
+            builder: GreenNodeBuilder::new(),
+        }
+    }
+
+    pub fn build(&mut self, node: &ResolvedNode) -> Result<(), String> {
+        self.builder.start_node(SyntaxKind::Root);
+        self.walk_and_build(node)?;
+        self.builder.finish_node();
+        Ok(())
+    }
+
+    fn walk_and_build(&mut self, node: &ResolvedNode) -> Result<(), String> {
+        // for now, just walk
+        use cstree::util::NodeOrToken;
+        let mut children = node.children_with_tokens();
+
+        while let Some(child) = children.next() {
+            match child {
+                NodeOrToken::Node(n) => {
+                    self.builder.start_node(n.kind());
+
+                    self.walk_and_build(n)?;
+
+                    self.builder.finish_node();
+                }
+                NodeOrToken::Token(t) => {
+                    let kind = t.kind();
+                    let text = t.text();
+                    println!("Token (kind: {kind:?}, text: {text})");
+
+                    // build
+                    self.builder.token(kind, text);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub fn finish(self) -> (GreenNode, impl Interner) {
+        let (tree, cache) = self.builder.finish();
+        (tree, cache.unwrap().into_interner().unwrap())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{cst, tree_sitter::transform::TreeBuilder, SyntaxNode};
+
+    #[test]
+    fn test() -> Result<(), String> {
+        let input = r#"
+SELECT
+	1 as X
+,	2
+,	3
+FROM
+	A
+,	B"#;
+        dbg!(input);
+        let root = cst::parse(input).unwrap();
+
+        let mut tree_builder = TreeBuilder::new();
+        tree_builder.build(&root)?;
+
+        let (tree, interner) = tree_builder.finish();
+        let new_root = SyntaxNode::new_root_with_resolver(tree, interner);
+
+        dbg!(&root);
+        dbg!(&new_root);
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
## 概要
パーサジェネレータが返すCSTを受け取り、tree-sitter-sql が返すものに似たCSTを構築する関数を実装しました（`tree_sitter::convert::convert_cst`）

## 変換処理
リスト系ノードのフラット化 および 不要なノードの除去を行っています

現時点で対象にしているノードは以下です：
- フラット化： `stmtmulti`, `target_list`, `from_list`
- 除去： `opt_target_list`

## その他
標準のassertionだとCSTに対するテストを書くのが難しかったので、いくつかユーティリティ関数を追加しました
`tree_sitter::assert_util` に配置されています