### PR TITLE
feature: tree-sitter like traverse API

### DIFF
--- a/crates/postgresql-cst-parser/examples/tree_sitter_like.rs
+++ b/crates/postgresql-cst-parser/examples/tree_sitter_like.rs
@@ -1,0 +1,49 @@
+use postgresql_cst_parser::{
+    parse,
+    tree_sitter::{as_tree_sitter_cursor, get_ts_tree_and_range_map, TreeCursor},
+};
+
+fn main() {
+    let src = r#"
+-- comment
+SELECT
+	1 as X
+,	2 -- comment
+,	3
+FROM
+	A
+,	B
+;
+select
+    1
+,   2
+;
+
+"#;
+
+    let node = parse(&src).unwrap();
+    let (node, range_map) = get_ts_tree_and_range_map(&src, &node);
+    let mut cursor = as_tree_sitter_cursor(src, &node, range_map);
+
+    visit(&mut cursor, 0, &src);
+}
+
+const UNIT: usize = 2;
+fn visit(cursor: &mut TreeCursor, depth: usize, src: &str) {
+    (0..(depth * UNIT)).for_each(|_| print!("-"));
+
+    print!("{}", cursor.node().kind());
+
+    if cursor.node().child_count() == 0 {
+        print!(" \"{}\"", cursor.node().text().escape_debug());
+    }
+    println!(" {}", cursor.node().range());
+
+    if cursor.goto_first_child() {
+        visit(cursor, depth + 1, src);
+        while cursor.goto_next_sibling() {
+            visit(cursor, depth + 1, src);
+        }
+        cursor.goto_parent();
+    }
+}

--- a/crates/postgresql-cst-parser/src/tree_sitter.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter.rs
@@ -345,11 +345,11 @@ select
         let (root, range_map) = get_ts_tree_and_range_map(&src, &parse(&src).unwrap());
         let first_select = root
             .descendants()
-            .find(|x| x.kind() == SyntaxKind::simple_select)
+            .find(|x| x.kind() == SyntaxKind::SelectStmt)
             .unwrap();
 
         let mut cursor = as_tree_sitter_cursor(src, &first_select, range_map);
-        assert_eq!(cursor.node().kind(), SyntaxKind::simple_select);
+        assert_eq!(cursor.node().kind(), SyntaxKind::SelectStmt);
 
         assert!(cursor.goto_first_child());
         assert_eq!(cursor.node().kind(), SyntaxKind::SELECT);

--- a/crates/postgresql-cst-parser/src/tree_sitter.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter.rs
@@ -48,43 +48,43 @@ impl std::fmt::Display for Range {
     }
 }
 
-fn is_flatten_all(node_or_token: NodeOrToken) -> bool {
-    matches!(
-        node_or_token.kind(),
-        SyntaxKind::parse_toplevel
-            | SyntaxKind::stmtmulti
-            | SyntaxKind::toplevel_stmt
-            | SyntaxKind::stmt
-            | SyntaxKind::select_clause
-            | SyntaxKind::select_with_parens
-            | SyntaxKind::select_no_parens
-            | SyntaxKind::simple_select
-            | SyntaxKind::opt_target_list
-            // | SyntaxKind::relation_expr
-            // | SyntaxKind::extended_relation_expr
-            // | SyntaxKind::qualified_name
-            // | SyntaxKind::indirection
-            // | SyntaxKind::indirection_el
-            // | SyntaxKind::table_ref
-            | SyntaxKind::alias_clause
-            | SyntaxKind::opt_alias_clause
-    )
-}
+// fn is_flatten_all(node_or_token: NodeOrToken) -> bool {
+//     matches!(
+//         node_or_token.kind(),
+//         SyntaxKind::parse_toplevel
+//             | SyntaxKind::stmtmulti
+//             | SyntaxKind::toplevel_stmt
+//             | SyntaxKind::stmt
+//             | SyntaxKind::select_clause
+//             | SyntaxKind::select_with_parens
+//             | SyntaxKind::select_no_parens
+//             | SyntaxKind::simple_select
+//             | SyntaxKind::opt_target_list
+//             // | SyntaxKind::relation_expr
+//             // | SyntaxKind::extended_relation_expr
+//             // | SyntaxKind::qualified_name
+//             // | SyntaxKind::indirection
+//             // | SyntaxKind::indirection_el
+//             // | SyntaxKind::table_ref
+//             | SyntaxKind::alias_clause
+//             | SyntaxKind::opt_alias_clause
+//     )
+// }
 
-fn is_flatten_except_top(node_or_token: NodeOrToken) -> bool {
-    matches!(
-        node_or_token.kind(),
-        SyntaxKind::target_list | SyntaxKind::from_list
-    ) && node_or_token.parent().unwrap().kind() == node_or_token.kind()
-}
+// fn is_flatten_except_top(node_or_token: NodeOrToken) -> bool {
+//     matches!(
+//         node_or_token.kind(),
+//         SyntaxKind::target_list | SyntaxKind::from_list
+//     ) && node_or_token.parent().unwrap().kind() == node_or_token.kind()
+// }
 
-fn is_flatten(node_or_token: NodeOrToken) -> bool {
-    is_flatten_all(node_or_token) || is_flatten_except_top(node_or_token)
-}
+// fn is_flatten(node_or_token: NodeOrToken) -> bool {
+//     is_flatten_all(node_or_token) || is_flatten_except_top(node_or_token)
+// }
 
-fn is_skip(kind: SyntaxKind) -> bool {
-    matches!(kind, SyntaxKind::Whitespace)
-}
+// fn is_skip(kind: SyntaxKind) -> bool {
+//     matches!(kind, SyntaxKind::Whitespace)
+// }
 
 impl<'a> Node<'a> {
     pub fn walk(&self) -> TreeCursor<'a> {

--- a/crates/postgresql-cst-parser/src/tree_sitter.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter.rs
@@ -58,44 +58,6 @@ impl std::fmt::Display for Range {
     }
 }
 
-// fn is_flatten_all(node_or_token: NodeOrToken) -> bool {
-//     matches!(
-//         node_or_token.kind(),
-//         SyntaxKind::parse_toplevel
-//             | SyntaxKind::stmtmulti
-//             | SyntaxKind::toplevel_stmt
-//             | SyntaxKind::stmt
-//             | SyntaxKind::select_clause
-//             | SyntaxKind::select_with_parens
-//             | SyntaxKind::select_no_parens
-//             | SyntaxKind::simple_select
-//             | SyntaxKind::opt_target_list
-//             // | SyntaxKind::relation_expr
-//             // | SyntaxKind::extended_relation_expr
-//             // | SyntaxKind::qualified_name
-//             // | SyntaxKind::indirection
-//             // | SyntaxKind::indirection_el
-//             // | SyntaxKind::table_ref
-//             | SyntaxKind::alias_clause
-//             | SyntaxKind::opt_alias_clause
-//     )
-// }
-
-// fn is_flatten_except_top(node_or_token: NodeOrToken) -> bool {
-//     matches!(
-//         node_or_token.kind(),
-//         SyntaxKind::target_list | SyntaxKind::from_list
-//     ) && node_or_token.parent().unwrap().kind() == node_or_token.kind()
-// }
-
-// fn is_flatten(node_or_token: NodeOrToken) -> bool {
-//     is_flatten_all(node_or_token) || is_flatten_except_top(node_or_token)
-// }
-
-// fn is_skip(kind: SyntaxKind) -> bool {
-//     matches!(kind, SyntaxKind::Whitespace)
-// }
-
 impl<'a> Node<'a> {
     pub fn walk(&self) -> TreeCursor<'a> {
         unimplemented!()
@@ -327,7 +289,7 @@ FROM
         const UNIT: usize = 2;
 
         fn visit(cursor: &mut TreeCursor, depth: usize, src: &str) {
-            (0..(depth * UNIT)).for_each(|_| print!(" "));
+            (0..(depth * UNIT)).for_each(|_| print!("-"));
 
             print!("{}", cursor.node().kind());
 
@@ -361,7 +323,14 @@ SELECT
 ,	3
 FROM
 	A
-,	B"#;
+,	B
+;
+select
+    1
+,   2
+;
+
+"#;
 
         let node = parse(&src).unwrap();
         let (node, range_map) = get_ts_tree_and_range_map(&src, &node);

--- a/crates/postgresql-cst-parser/src/tree_sitter.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter.rs
@@ -68,7 +68,6 @@ impl<'a> Node<'a> {
     }
 
     pub fn range(&self) -> Range {
-        // dbg!(self.node_or_token.text_range(), &self.range_map);
         self.range_map
             .get(&self.node_or_token.text_range())
             .cloned()
@@ -91,10 +90,6 @@ impl<'a> Node<'a> {
         } = self.range();
 
         &self.input[start_byte..end_byte]
-    }
-
-    pub fn utf8_text() {
-        unimplemented!()
     }
 
     pub fn child_count(&self) -> usize {
@@ -187,61 +182,15 @@ pub fn as_tree_sitter_cursor<'a>(
     }
 }
 
-pub fn dump_as_tree_sitter_like(input: &str, node: &ResolvedNode) {
-    let (node, range_map) = get_ts_tree_and_range_map(input, node);
-    let mut cursor = as_tree_sitter_cursor(input, &node, range_map);
-
-    let mut depth = 0;
-    loop {
-        dbg!(cursor.node().kind(), cursor.node().text(), depth);
-
-        if cursor.goto_first_child() {
-            depth += 1;
-        } else if cursor.goto_next_sibling() {
-        } else {
-            loop {
-                if !cursor.goto_parent() {
-                    return;
-                }
-
-                depth -= 1;
-                if cursor.goto_next_sibling() {
-                    break;
-                }
-            }
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use crate::{
-        cst, parse,
+        parse,
         syntax_kind::SyntaxKind,
         tree_sitter::{
-            as_tree_sitter_cursor, dump_as_tree_sitter_like, get_ts_tree_and_range_map, TreeCursor,
+            as_tree_sitter_cursor, get_ts_tree_and_range_map, TreeCursor,
         },
-        ParseError,
     };
-
-    #[test]
-    fn test() -> Result<(), ParseError> {
-        let input = r#"
-SELECT
-	1 as X
-,	2
-,	3
-FROM
-	A
-,	B"#;
-        // dbg!(input);
-        let node = cst::parse(input)?;
-        // dbg!(&node);
-
-        dump_as_tree_sitter_like(input, &node);
-
-        Ok(())
-    }
 
     #[test]
     fn tree_sitter_like_traverse() {

--- a/crates/postgresql-cst-parser/src/tree_sitter.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter.rs
@@ -167,15 +167,6 @@ impl<'a> TreeCursor<'a> {
         }
     }
 
-    pub fn goto_direct_prev_sibling(&mut self) -> bool {
-        if let Some(prev) = self.node_or_token.prev_sibling_or_token() {
-            self.node_or_token = prev;
-            true
-        } else {
-            false
-        }
-    }
-
     pub fn is_comment(&self) -> bool {
         matches!(
             self.node_or_token.kind(),

--- a/crates/postgresql-cst-parser/src/tree_sitter.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter.rs
@@ -109,9 +109,12 @@ impl<'a> Node<'a> {
         &self.input[start..end]
     }
 
-    pub fn children(&self) {}
-
-    pub fn child_count(&self) {}
+    pub fn child_count(&self) -> usize {
+        if let Some(node) = self.node_or_token.as_node() {
+            return node.children_with_tokens().count();
+        }
+        0
+    }
 
     pub fn next_sibling(&self) -> Option<Node<'a>> {
         self.node_or_token

--- a/crates/postgresql-cst-parser/src/tree_sitter.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter.rs
@@ -59,8 +59,8 @@ impl std::fmt::Display for Range {
 }
 
 impl<'a> Node<'a> {
-    pub fn walk(&self) -> TreeCursor<'a> {
-        unimplemented!()
+    pub fn walk(&self, src: &'a str, range_map: HashMap<TextRange, Range>) -> TreeCursor<'a> {
+        as_tree_sitter_cursor(src, self.node_or_token.as_node().unwrap(), range_map)
     }
 
     pub fn kind(&self) -> SyntaxKind {
@@ -189,6 +189,19 @@ mod tests {
         syntax_kind::SyntaxKind,
         tree_sitter::{as_tree_sitter_cursor, get_ts_tree_and_range_map},
     };
+    
+    #[test]
+    fn walk() {
+        let src = "select a, b, c from tbl;";
+        let (root, range_map) = get_ts_tree_and_range_map(&src, &parse(&src).unwrap());
+
+        let mut cursor = as_tree_sitter_cursor(src, &root, range_map.clone());
+        cursor.goto_first_child();
+        let node = cursor.node();
+        
+        let new_cursor = node.walk(src, range_map);
+        assert_eq!(cursor.node().kind(), new_cursor.node().kind())
+    }
 
     #[test]
     fn goto_first_child_from_node() {

--- a/crates/postgresql-cst-parser/src/tree_sitter.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter.rs
@@ -196,38 +196,6 @@ pub fn as_tree_sitter_cursor<'a>(
     }
 }
 
-fn traverse_pre_order<F: FnMut(NodeOrToken)>(node: &ResolvedNode, mut f: F) {
-    let mut node_or_token = NodeOrToken::Node(node);
-
-    loop {
-        f(node_or_token);
-
-        if let Some(node) = node_or_token.as_node() {
-            if let Some(child) = node.first_child_or_token() {
-                node_or_token = child;
-                continue;
-            }
-        }
-
-        if let Some(sibling) = node_or_token.next_sibling_or_token() {
-            node_or_token = sibling;
-        } else {
-            loop {
-                if let Some(parent) = node_or_token.parent() {
-                    node_or_token = NodeOrToken::Node(parent);
-                } else {
-                    return;
-                }
-
-                if let Some(sibling) = node_or_token.next_sibling_or_token() {
-                    node_or_token = sibling;
-                    break;
-                }
-            }
-        }
-    }
-}
-
 pub fn dump_as_tree_sitter_like(input: &str, node: &ResolvedNode) {
     let (node, range_map) = get_ts_tree_and_range_map(input, node);
     let mut cursor = as_tree_sitter_cursor(input, &node, range_map);

--- a/crates/postgresql-cst-parser/src/tree_sitter.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter.rs
@@ -133,6 +133,14 @@ impl<'a> From<Node<'a>> for TreeCursor<'a> {
 }
 
 impl<'a> TreeCursor<'a> {
+    pub fn node(&self) -> Node<'a> {
+        Node {
+            input: self.input,
+            range_map: Rc::clone(&self.range_map),
+            node_or_token: self.node_or_token,
+        }
+    }
+
     pub fn goto_first_child(&mut self) -> bool {
         if self.node_or_token.as_node().is_none() {
             return false;
@@ -166,6 +174,20 @@ impl<'a> TreeCursor<'a> {
                 cursor.node_or_token = NodeOrToken::Node(cursor.node_or_token.parent().unwrap());
             }
         }
+    }
+
+    pub fn goto_parent(&mut self) -> bool {
+        while let Some(parent) = self.node_or_token.parent() {
+            self.node_or_token = NodeOrToken::Node(parent);
+
+            if is_flatten(self.node_or_token) {
+                continue;
+            }
+
+            return true;
+        }
+
+        false
     }
 
     pub fn goto_next_sibling(&mut self) -> bool {
@@ -205,28 +227,6 @@ impl<'a> TreeCursor<'a> {
             true
         } else {
             false
-        }
-    }
-
-    pub fn goto_parent(&mut self) -> bool {
-        while let Some(parent) = self.node_or_token.parent() {
-            self.node_or_token = NodeOrToken::Node(parent);
-
-            if is_flatten(self.node_or_token) {
-                continue;
-            }
-
-            return true;
-        }
-
-        false
-    }
-
-    pub fn node(&self) -> Node<'a> {
-        Node {
-            input: self.input,
-            range_map: Rc::clone(&self.range_map),
-            node_or_token: self.node_or_token,
         }
     }
 

--- a/crates/postgresql-cst-parser/src/tree_sitter.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter.rs
@@ -187,65 +187,8 @@ mod tests {
     use crate::{
         parse,
         syntax_kind::SyntaxKind,
-        tree_sitter::{
-            as_tree_sitter_cursor, get_ts_tree_and_range_map, TreeCursor,
-        },
+        tree_sitter::{as_tree_sitter_cursor, get_ts_tree_and_range_map},
     };
-
-    #[test]
-    fn tree_sitter_like_traverse() {
-        const UNIT: usize = 2;
-
-        fn visit(cursor: &mut TreeCursor, depth: usize, src: &str) {
-            (0..(depth * UNIT)).for_each(|_| print!("-"));
-
-            print!("{}", cursor.node().kind());
-
-            if cursor.node().child_count() == 0 {
-                // print!(" \"{}\"", cursor.node().utf8_text(src.as_bytes()).unwrap()); // tree-sitter style
-                print!(" \"{}\"", cursor.node().text().escape_default()); // postgresql-cst-parser style
-            }
-            println!(
-                // " [{}-{}]",
-                // cursor.node().start_position(),
-                // cursor.node().end_position()
-                " {}",
-                cursor.node().range()
-            );
-
-            // 子供を走査
-            if cursor.goto_first_child() {
-                visit(cursor, depth + 1, src);
-                while cursor.goto_next_sibling() {
-                    visit(cursor, depth + 1, src);
-                }
-                cursor.goto_parent();
-            }
-        }
-
-        let src = r#"
--- comment
-SELECT
-	1 as X
-,	2 -- comment
-,	3
-FROM
-	A
-,	B
-;
-select
-    1
-,   2
-;
-
-"#;
-
-        let node = parse(&src).unwrap();
-        let (node, range_map) = get_ts_tree_and_range_map(&src, &node);
-        let mut cursor = as_tree_sitter_cursor(src, &node, range_map);
-
-        visit(&mut cursor, 0, &src);
-    }
 
     #[test]
     fn goto_first_child_from_node() {

--- a/crates/postgresql-cst-parser/src/tree_sitter.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter.rs
@@ -40,7 +40,11 @@ pub struct Range {
 
 impl std::fmt::Display for Range {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "[({}, {})-({}, {})]", self.start_row, self.start_col, self.end_row, self.end_col)
+        write!(
+            f,
+            "[({}, {})-({}, {})]",
+            self.start_row, self.start_col, self.end_row, self.end_col
+        )
     }
 }
 

--- a/crates/postgresql-cst-parser/src/tree_sitter.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter.rs
@@ -182,29 +182,6 @@ impl<'a> TreeCursor<'a> {
         false
     }
 
-    ///
-    /// These methods are unused in uroborosql-fmt
-    ///
-    // pub fn field_id(&self)-> Option<u16> {
-    //     unimplemented!()
-    // }
-
-    // pub fn field_name(&self)-> Option<&'static str> {
-    //     unimplemented!()
-    // }
-
-    // pub fn goto_first_child_for_byte(&mut self, index: usize) -> Option<usize> {
-    //     unimplemented!()
-    // }
-
-    // pub fn goto_first_child_for_point(&mut self, point: Point) -> Option<usize> {
-    //  unimplemented!()
-    // }
-
-    // pub fn reset(&mut self, node: Node<'a>) {
-    //     unimplemented!()
-    // }
-
     pub fn goto_direct_prev_sibling(&mut self) -> bool {
         if let Some(prev) = self.node_or_token.prev_sibling_or_token() {
             self.node_or_token = prev;

--- a/crates/postgresql-cst-parser/src/tree_sitter.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter.rs
@@ -38,6 +38,12 @@ pub struct Range {
     pub end_col: usize,
 }
 
+impl std::fmt::Display for Range {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "[({}, {})-({}, {})]", self.start_row, self.start_col, self.end_row, self.end_col)
+    }
+}
+
 fn is_flatten_all(node_or_token: NodeOrToken) -> bool {
     matches!(
         node_or_token.kind(),

--- a/crates/postgresql-cst-parser/src/tree_sitter/convert.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter/convert.rs
@@ -1,28 +1,86 @@
-use cstree::{build::GreenNodeBuilder, syntax::SyntaxNode};
+use std::collections::HashMap;
+
+use cstree::{build::GreenNodeBuilder, syntax::SyntaxNode, text::TextRange};
 
 use crate::{syntax_kind::SyntaxKind, PostgreSQLSyntax, ResolvedNode};
 
+use super::{traverse_pre_order, Range};
+
 /// Converts the given CST into a node structure and hierarchy that closely matches what `tree-sitter-sql` produces.
-pub fn convert_cst(root: &ResolvedNode) -> ResolvedNode {
+pub fn convert_cst(src: &str, root: &ResolvedNode) -> (ResolvedNode, HashMap<TextRange, Range>) {
     let mut builder = GreenNodeBuilder::new();
+    let mut range_vec = vec![];
 
     // Build `Root` node
     builder.start_node(SyntaxKind::Root);
-    walk_and_build(&mut builder, root);
+    walk_and_build(src, &mut builder, &mut range_vec, root);
     builder.finish_node();
 
     let (tree, cache) = builder.finish();
+    let resolved_node =
+        SyntaxNode::new_root_with_resolver(tree, cache.unwrap().into_interner().unwrap());
 
-    SyntaxNode::new_root_with_resolver(tree, cache.unwrap().into_interner().unwrap())
+    let mut range_map = HashMap::new();
+    let mut ranges = range_vec.iter();
+    traverse_pre_order(&resolved_node, |node_or_token| {
+        if let Some(original_range) = ranges.next() {
+            // clone?
+            range_map.insert(node_or_token.text_range(), original_range.clone());
+        } else {
+            unreachable!()
+        }
+    });
+
+    (resolved_node, range_map)
 }
 
 /// Traverse the CST and rewrite certain nodes
 /// e.g. flatten list node, remove option node
 fn walk_and_build(
+    input: &str,
     builder: &mut GreenNodeBuilder<'static, 'static, PostgreSQLSyntax>,
+    range_vec: &mut Vec<Range>,
     node: &ResolvedNode,
 ) {
     use cstree::util::NodeOrToken;
+
+    let new_line_indices: Vec<_> = input
+        .char_indices()
+        .filter(|&(_, c)| c == '\n')
+        .map(|(i, _)| i)
+        .collect();
+
+    let text_range = node.text_range();
+
+    // text_range の初期部分が、改行のどの部分に現れるか
+    let before_start_new_line_count =
+        match new_line_indices.binary_search(&text_range.start().into()) {
+            Ok(i) => i,
+            Err(i) => i,
+        };
+
+    let before_end_new_line_count = match new_line_indices.binary_search(&text_range.end().into()) {
+        Ok(i) => i,
+        Err(i) => i,
+    };
+
+    range_vec.push(Range {
+        start_row: before_start_new_line_count,
+        start_col: usize::from(node.text_range().start())
+            - match before_start_new_line_count {
+                0 => 0,
+                // ひとつ前のインデックス（直前の改行文字）+1
+                i => new_line_indices[i - 1] + 1, // +1 は改行文字分？
+            },
+        end_row: before_end_new_line_count,
+        end_col: usize::from(node.text_range().end())
+            - 1
+            - match before_end_new_line_count {
+                0 => 0,
+                i => new_line_indices[i - 1],
+            },
+    });
+
     let parent_kind = node.kind();
     let children = node.children_with_tokens();
 
@@ -44,15 +102,22 @@ fn walk_and_build(
                             //     +- target_el
                             //     +- ...
                             //
-                            walk_and_build(builder, n);
+                            walk_and_build(input, builder, range_vec, n);
                         } else {
                             // Node is target for flattening, but at the top level of the nest
                             builder.start_node(n.kind());
-                            walk_and_build(builder, n);
+                            walk_and_build(input, builder, range_vec, n);
                             builder.finish_node();
                         }
                     }
 
+                    // SyntaxKind::parse_toplevel
+                    // | SyntaxKind::stmtmulti
+                    // | SyntaxKind::toplevel_stmt
+                    // | SyntaxKind::stmt
+                    // | SyntaxKind::select_no_parens
+                    // | SyntaxKind::simple_select
+                    // |
                     SyntaxKind::opt_target_list => {
                         // [Removal]
                         //
@@ -64,18 +129,26 @@ fn walk_and_build(
                         //       +- child_1                                          +- child_2
                         //       +- child_1
                         //
-                        walk_and_build(builder, n);
+                        walk_and_build(input, builder, range_vec, n);
                     }
 
                     // Default pattern
                     _ => {
                         builder.start_node(n.kind());
-                        walk_and_build(builder, n);
+                        walk_and_build(input, builder, range_vec, n);
                         builder.finish_node();
                     }
                 }
             }
             NodeOrToken::Token(t) => {
+                // Remove Whitespace Token
+                // Note:
+                //   This process will break the lossless property of the CST.
+                //   `text()` for Nodes and `text_range()` for Nodes and Tokens will become incompatible with the original text.
+                if t.kind() == SyntaxKind::Whitespace {
+                    continue;
+                }
+
                 builder.token(t.kind(), t.text());
             }
         }
@@ -87,9 +160,8 @@ mod tests {
     use crate::{cst, tree_sitter::convert::convert_cst};
 
     #[test]
-    ///  Assert that the CST is not broken by the conversion.
-    fn restored_texts_are_equal() {
-        let input = r#"
+    fn whitespace_is_removed() {
+        let original = r#"
 SELECT
 	1 as X
 ,	2
@@ -98,11 +170,12 @@ FROM
 	A
 ,	B"#;
 
-        let root = cst::parse(input).unwrap();
-        let new_root = convert_cst(&root);
+        let root = cst::parse(&original).unwrap();
+        let new_root = convert_cst(&original, &root);
 
-        //  format!("{ResolvedNode}") returns original input str.
-        assert_eq!(format!("{root}"), format!("{new_root}"));
+        let whitespace_removed: String = original.split_whitespace().collect();
+        dbg!(&whitespace_removed);
+        assert_eq!(new_root.text(), whitespace_removed.as_str());
     }
 
     mod removal {
@@ -121,7 +194,7 @@ FROM
             let root = cst::parse(input).unwrap();
             assert_exists(&root, SyntaxKind::opt_target_list);
 
-            let new_root = convert_cst(&root);
+            let new_root = convert_cst(input, &root);
             assert_not_exists(&new_root, SyntaxKind::opt_target_list);
         }
     }
@@ -143,7 +216,7 @@ FROM
             let root = cst::parse(input).unwrap();
             assert_node_count(&root, SyntaxKind::target_list, 3);
 
-            let new_root = convert_cst(&root);
+            let new_root = convert_cst(input, &root);
             assert_node_count(&new_root, SyntaxKind::target_list, 1);
             assert_no_direct_nested_kind(&new_root, SyntaxKind::target_list);
         }
@@ -152,7 +225,7 @@ FROM
         fn no_nested_stmtmulti() {
             let input = "select a,b,c;\nselect d,e from t;";
             let root = cst::parse(input).unwrap();
-            let new_root = convert_cst(&root);
+            let new_root = convert_cst(&input, &root);
 
             assert_no_direct_nested_kind(&new_root, SyntaxKind::stmtmulti);
         }
@@ -161,7 +234,7 @@ FROM
         fn no_nested_from_list() {
             let input = "select * from t1, t2;";
             let root = cst::parse(input).unwrap();
-            let new_root = convert_cst(&root);
+            let new_root = convert_cst(input, &root);
 
             assert_no_direct_nested_kind(&new_root, SyntaxKind::from_list);
         }

--- a/crates/postgresql-cst-parser/src/tree_sitter/convert.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter/convert.rs
@@ -40,7 +40,7 @@ pub fn get_ts_tree_and_range_map(
         // 1. Add new Node (or Token) to New Tree
         // 2. Create tree-sitter compatible `Range`s based on the original text.
         walk_and_build(
-            &root,
+            root,
             &new_line_indices,
             &mut builder,
             &mut row_column_ranges,
@@ -59,10 +59,7 @@ pub fn get_ts_tree_and_range_map(
     (new_root, range_map)
 }
 
-fn get_row_column_range(
-    node_or_token: &NodeOrToken,
-    new_line_indices: &Vec<usize>,
-) -> RowColumnRange {
+fn get_row_column_range(node_or_token: &NodeOrToken, new_line_indices: &[usize]) -> RowColumnRange {
     let text_range: SequentialRange = node_or_token.text_range();
 
     let before_start_new_line_count =
@@ -146,7 +143,7 @@ fn create_mapping(
 
     let mut range_map: HashMap<SequentialRange, RowColumnRange> = HashMap::new();
     let mut range_iter = row_column_ranges.iter();
-    traverse_pre_order(&root, |node_or_token| {
+    traverse_pre_order(root, |node_or_token| {
         if let Some(original_range) = range_iter.next() {
             let byte_range = node_or_token.text_range();
             range_map.insert(byte_range, original_range.clone());
@@ -194,8 +191,8 @@ fn walk_and_build(
                             // Node is target for flattening, but at the top level of the nest
 
                             row_column_ranges.push(get_row_column_range(
-                                &NodeOrToken::Node(&child_node),
-                                &new_line_indices,
+                                &NodeOrToken::Node(child_node),
+                                new_line_indices,
                             ));
 
                             builder.start_node(child_node.kind());
@@ -232,8 +229,8 @@ fn walk_and_build(
                     // [Node: Default]
                     _ => {
                         row_column_ranges.push(get_row_column_range(
-                            &NodeOrToken::Node(&child_node),
-                            &new_line_indices,
+                            &NodeOrToken::Node(child_node),
+                            new_line_indices,
                         ));
                         builder.start_node(child_node.kind());
                         walk_and_build(child_node, new_line_indices, builder, row_column_ranges);
@@ -253,7 +250,7 @@ fn walk_and_build(
                 // [Token: Default]
                 row_column_ranges.push(get_row_column_range(
                     &NodeOrToken::Token(child_token),
-                    &new_line_indices,
+                    new_line_indices,
                 ));
                 builder.token(child_token.kind(), child_token.text());
             }

--- a/crates/postgresql-cst-parser/src/tree_sitter/convert.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter/convert.rs
@@ -140,8 +140,8 @@ fn walk_and_build(
         match child {
             NodeOrToken::Node(child_node) => {
                 match child_node.kind() {
-                    child_kind @ (SyntaxKind::stmtmulti
-                    | SyntaxKind::target_list
+                    child_kind @ (
+                    SyntaxKind::target_list
                     | SyntaxKind::from_list) => {
                         if parent_kind == child_kind {
                             // [Node: Flatten]
@@ -179,14 +179,13 @@ fn walk_and_build(
                         }
                     }
 
-                    // SyntaxKind::parse_toplevel
-                    // | SyntaxKind::stmtmulti
-                    // | SyntaxKind::toplevel_stmt
-                    // | SyntaxKind::stmt
-                    // | SyntaxKind::select_no_parens
-                    // | SyntaxKind::simple_select
-                    // |
-                    SyntaxKind::opt_target_list => {
+                    SyntaxKind::parse_toplevel
+                    | SyntaxKind::stmtmulti
+                    | SyntaxKind::toplevel_stmt
+                    | SyntaxKind::stmt
+                    | SyntaxKind::select_no_parens
+                    | SyntaxKind::simple_select
+                    | SyntaxKind::opt_target_list => {
                         // [Node: Removal]
                         //
                         // Ignore current node, and continue building its children.

--- a/crates/postgresql-cst-parser/src/tree_sitter/convert.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter/convert.rs
@@ -4,7 +4,7 @@ use cstree::{build::GreenNodeBuilder, syntax::SyntaxNode};
 
 use crate::{syntax_kind::SyntaxKind, NodeOrToken, PostgreSQLSyntax, ResolvedNode};
 
-use super::traverse_pre_order;
+use super::{traverse_pre_order, Point};
 
 type SequentialRange = cstree::text::TextRange; // Range representation by cstree (Sequential bytes)
 type RowColumnRange = super::Range; // tree-sitter like range representation (Rows and Columns)
@@ -197,12 +197,7 @@ fn walk_and_build(
                         //       +- child_1                                          +- child_2
                         //       +- child_1
                         //
-                        walk_and_build(
-                            child_node,
-                            new_line_indices,
-                            builder,
-                            row_column_ranges,
-                        );
+                        walk_and_build(child_node, new_line_indices, builder, row_column_ranges);
                     }
 
                     // [Node: Default]
@@ -212,12 +207,7 @@ fn walk_and_build(
                             &new_line_indices,
                         ));
                         builder.start_node(child_node.kind());
-                        walk_and_build(
-                            child_node,
-                            new_line_indices,
-                            builder,
-                            row_column_ranges,
-                        );
+                        walk_and_build(child_node, new_line_indices, builder, row_column_ranges);
                         builder.finish_node();
                     }
                 }

--- a/crates/postgresql-cst-parser/src/tree_sitter/convert.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter/convert.rs
@@ -76,20 +76,30 @@ fn get_row_column_range(
         Err(i) => i,
     };
 
-    RowColumnRange {
-        start_row: before_start_new_line_count,
-        start_col: usize::from(text_range.start())
+    let start_position = Point {
+        row: before_start_new_line_count,
+        column: usize::from(text_range.start())
             - match before_start_new_line_count {
                 0 => 0,
                 i => new_line_indices[i - 1] + 1,
             },
-        end_row: before_end_new_line_count,
-        end_col: usize::from(text_range.end())
+    };
+
+    let end_position = Point {
+        row: before_end_new_line_count,
+        column: usize::from(text_range.end())
             - 1
             - match before_end_new_line_count {
                 0 => 0,
                 i => new_line_indices[i - 1],
             },
+    };
+
+    RowColumnRange {
+        start_byte: text_range.start().into(),
+        end_byte: text_range.end().into(),
+        start_position,
+        end_position,
     }
 }
 

--- a/crates/postgresql-cst-parser/src/tree_sitter/convert.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter/convert.rs
@@ -182,6 +182,7 @@ fn walk_and_build(
                     | SyntaxKind::stmt
                     | SyntaxKind::select_no_parens
                     | SyntaxKind::simple_select
+                    | SyntaxKind::select_clause
                     | SyntaxKind::opt_target_list => {
                         // [Node: Removal]
                         //


### PR DESCRIPTION
## Summary
- tree-sitter ライクな Cursor を返すAPIを実装
  - [`fn get_ts_tree_and_range_map`](https://github.com/future-architect/postgresql-cst-parser/blob/1a3e55d6ddc9a00c05f2b6275518d71509b9f6f6/crates/postgresql-cst-parser/src/tree_sitter/convert.rs#L12-L15)
  - [`fn as_tree_sitter_cursor`](https://github.com/future-architect/postgresql-cst-parser/blob/1a3e55d6ddc9a00c05f2b6275518d71509b9f6f6/crates/postgresql-cst-parser/src/tree_sitter.rs#L187-L191)
- `(row, column)` 形式の Range 取得に対応
- tree-sitter が持つトラバースAPI（の一部）を実装