### PR TITLE
tree-sitter like api: flatten expr_list node

### DIFF
--- a/crates/postgresql-cst-parser/src/tree_sitter/convert.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter/convert.rs
@@ -140,7 +140,8 @@ fn walk_and_build(
                 match child_node.kind() {
                     child_kind @ (SyntaxKind::target_list
                     | SyntaxKind::from_list
-                    | SyntaxKind::indirection) => {
+                    | SyntaxKind::indirection
+                    | SyntaxKind::expr_list) => {
                         if parent_kind == child_kind {
                             // [Node: Flatten]
                             //
@@ -322,6 +323,15 @@ FROM
             let (new_root, _) = get_ts_tree_and_range_map(&input, &root);
 
             assert_no_direct_nested_kind(&new_root, SyntaxKind::indirection);
+        }
+
+        #[test]
+        fn no_nested_expr_list() {
+            let input = "select a from t where a in (1,2,3);";
+            let root = cst::parse(input).unwrap();
+            let (new_root, _) = get_ts_tree_and_range_map(&input, &root);
+
+            assert_no_direct_nested_kind(&new_root, SyntaxKind::expr_list);
         }
     }
 }


### PR DESCRIPTION
## Summary
`expr_list` ノードを flatten しました

## expr_list
`expr_list` は `IN` 式などで登場するノードで、`IN`式では括弧の中の部分にあたります。
```sql
select n from t where n in ( 1, 2, 3 );
--                           ^^^^^^^ expr_list
```
postgres における定義： https://github.com/postgres/postgres/blob/424ededc580b03e1bcf8aff18a735e519c80061f/src/backend/parser/gram.y#L16680-L16688