### PR TITLE
flatten func_arg_list

### DIFF
--- a/crates/postgresql-cst-parser/src/tree_sitter/convert.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter/convert.rs
@@ -141,7 +141,8 @@ fn walk_and_build(
                     child_kind @ (SyntaxKind::target_list
                     | SyntaxKind::from_list
                     | SyntaxKind::indirection
-                    | SyntaxKind::expr_list) => {
+                    | SyntaxKind::expr_list
+                    | SyntaxKind::func_arg_list) => {
                         if parent_kind == child_kind {
                             // [Node: Flatten]
                             //
@@ -332,6 +333,15 @@ FROM
             let (new_root, _) = get_ts_tree_and_range_map(&input, &root);
 
             assert_no_direct_nested_kind(&new_root, SyntaxKind::expr_list);
+        }
+
+        #[test]
+        fn no_nested_func_arg_list() {
+            let input = "select func(1, 2, func2(3, 4), 5);";
+            let root = cst::parse(input).unwrap();
+            let (new_root, _) = get_ts_tree_and_range_map(&input, &root);
+
+            assert_no_direct_nested_kind(&new_root, SyntaxKind::func_arg_list);
         }
     }
 }


### PR DESCRIPTION
関数の引数部分にあたるノード `func_arg_list` をフラット化しました

postgres における`func_arg_list` の定義: https://github.com/postgres/postgres/blob/76def4cdd7c2b32d19e950a160f834392ea51744/src/backend/parser/gram.y#L16718-L16727