### PR TITLE
flatten when_clause_list

### DIFF
--- a/crates/postgresql-cst-parser/src/tree_sitter/convert.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter/convert.rs
@@ -142,7 +142,8 @@ fn walk_and_build(
                     | SyntaxKind::from_list
                     | SyntaxKind::indirection
                     | SyntaxKind::expr_list
-                    | SyntaxKind::func_arg_list) => {
+                    | SyntaxKind::func_arg_list
+                    | SyntaxKind::when_clause_list) => {
                         if parent_kind == child_kind {
                             // [Node: Flatten]
                             //
@@ -342,6 +343,15 @@ FROM
             let (new_root, _) = get_ts_tree_and_range_map(&input, &root);
 
             assert_no_direct_nested_kind(&new_root, SyntaxKind::func_arg_list);
+        }
+
+        #[test]
+        fn no_nested_when_clause_list() {
+            let input = "select case when a then b when c then d when e then f else g end;";
+            let root = cst::parse(input).unwrap();
+            let (new_root, _) = get_ts_tree_and_range_map(&input, &root);
+
+            assert_no_direct_nested_kind(&new_root, SyntaxKind::when_clause_list);
         }
     }
 }


### PR DESCRIPTION
## Summary

`when_clause_list` をフラット化しました

when_clause_list は CASE式で登場する要素です。
```
case_expr:	CASE case_arg when_clause_list case_default END_P
```

```yacc
when_clause_list:
			/* There must be at least one */
			when_clause								{ $$ = list_make1($1); }
			| when_clause_list when_clause			{ $$ = lappend($1, $2); }
		;
```
postgres における定義： https://github.com/postgres/postgres/blob/c462b054ba605d23c1ec139fcca3d758ac139026/src/backend/parser/gram.y#L16926-L16930