### PR TITLE
flatten groupby_list

### DIFF
--- a/crates/postgresql-cst-parser/src/tree_sitter/convert.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter/convert.rs
@@ -144,6 +144,7 @@ fn walk_and_build(
                     | SyntaxKind::expr_list
                     | SyntaxKind::func_arg_list
                     | SyntaxKind::when_clause_list
+                    | SyntaxKind::group_by_list
                     | SyntaxKind::sortby_list) => {
                         if parent_kind == child_kind {
                             // [Node: Flatten]
@@ -362,6 +363,15 @@ FROM
             let (new_root, _) = get_ts_tree_and_range_map(&input, &root);
 
             assert_no_direct_nested_kind(&new_root, SyntaxKind::sortby_list);
+        }
+
+        #[test]
+        fn no_nested_groupby_list() {
+            let input = "select a, b, c from t group by a, b, c;";
+            let root = cst::parse(input).unwrap();
+            let (new_root, _) = get_ts_tree_and_range_map(&input, &root);
+
+            assert_no_direct_nested_kind(&new_root, SyntaxKind::group_by_list);
         }
     }
 }


### PR DESCRIPTION
## Summary

group by 句に現れる `groupby_list` をフラット化しました

https://github.com/postgres/postgres/blob/4a02af8b1a5f3f8221c7381bc4de08a3d830f682/src/backend/parser/gram.y#L13486-L13489