### PR TITLE
flatten for_locking_items

### DIFF
--- a/crates/postgresql-cst-parser/src/tree_sitter/convert.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter/convert.rs
@@ -145,7 +145,8 @@ fn walk_and_build(
                     | SyntaxKind::func_arg_list
                     | SyntaxKind::when_clause_list
                     | SyntaxKind::group_by_list
-                    | SyntaxKind::sortby_list) => {
+                    | SyntaxKind::sortby_list
+                    | SyntaxKind::for_locking_items) => {
                         if parent_kind == child_kind {
                             // [Node: Flatten]
                             //
@@ -372,6 +373,15 @@ FROM
             let (new_root, _) = get_ts_tree_and_range_map(&input, &root);
 
             assert_no_direct_nested_kind(&new_root, SyntaxKind::group_by_list);
+        }
+
+        #[test]
+        fn no_nested_for_locking_items() {
+            let input = "select * from t1, t2 for update of t1 for update of t2;";
+            let root = cst::parse(input).unwrap();
+            let (new_root, _) = get_ts_tree_and_range_map(&input, &root);
+
+            assert_no_direct_nested_kind(&new_root, SyntaxKind::for_locking_items);
         }
     }
 }

--- a/crates/postgresql-cst-parser/src/tree_sitter/convert.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter/convert.rs
@@ -146,6 +146,7 @@ fn walk_and_build(
                     | SyntaxKind::when_clause_list
                     | SyntaxKind::group_by_list
                     | SyntaxKind::sortby_list
+                    | SyntaxKind::qualified_name_list
                     | SyntaxKind::for_locking_items) => {
                         if parent_kind == child_kind {
                             // [Node: Flatten]
@@ -382,6 +383,15 @@ FROM
             let (new_root, _) = get_ts_tree_and_range_map(&input, &root);
 
             assert_no_direct_nested_kind(&new_root, SyntaxKind::for_locking_items);
+        }
+
+        #[test]
+        fn no_nested_qualified_name_list() {
+            let input = "select a from t for update of t.a, t.b;";
+            let root = cst::parse(input).unwrap();
+            let (new_root, _) = get_ts_tree_and_range_map(&input, &root);
+
+            assert_no_direct_nested_kind(&new_root, SyntaxKind::qualified_name_list);
         }
     }
 }


### PR DESCRIPTION
## Summary

for update で現れる、 `for_locking_items` および `qualified_name_list` をフラット化しました

`for_locking_items`: https://github.com/postgres/postgres/blob/master/src/backend/parser/gram.y#L13548-L13550
`qualified_name_list`: https://github.com/postgres/postgres/blob/5d5f415816a60a3c5c5e4420eff55e73edfbd9f5/src/backend/parser/gram.y#L17312-L17315