### PR TITLE
Remove select_limit, opt_select_limit

### DIFF
--- a/crates/postgresql-cst-parser/src/tree_sitter/convert.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter/convert.rs
@@ -192,6 +192,7 @@ fn walk_and_build(
                     | SyntaxKind::simple_select
                     | SyntaxKind::select_clause
                     | SyntaxKind::opt_select_limit
+                    | SyntaxKind::select_limit
                     | SyntaxKind::opt_target_list => {
                         // [Node: Removal]
                         //
@@ -289,6 +290,16 @@ FROM
 
             let (new_root, _) = get_ts_tree_and_range_map(input, &root);
             assert_not_exists(&new_root, SyntaxKind::opt_select_limit);
+        }
+
+        #[test]
+        fn no_select_limit() {
+            let input = "select a from t limit 5 offset 5;";
+            let root = cst::parse(input).unwrap();
+            assert_exists(&root, SyntaxKind::select_limit);
+
+            let (new_root, _) = get_ts_tree_and_range_map(input, &root);
+            assert_not_exists(&new_root, SyntaxKind::select_limit);
         }
     }
 

--- a/crates/postgresql-cst-parser/src/tree_sitter/convert.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter/convert.rs
@@ -191,6 +191,7 @@ fn walk_and_build(
                     | SyntaxKind::select_no_parens
                     | SyntaxKind::simple_select
                     | SyntaxKind::select_clause
+                    | SyntaxKind::opt_select_limit
                     | SyntaxKind::opt_target_list => {
                         // [Node: Removal]
                         //
@@ -278,6 +279,16 @@ FROM
 
             let (new_root, _) = get_ts_tree_and_range_map(input, &root);
             assert_not_exists(&new_root, SyntaxKind::opt_target_list);
+        }
+
+        #[test]
+        fn no_opt_select_limit() {
+            let input = "select a from t for update limit 5 offset 5;";
+            let root = cst::parse(input).unwrap();
+            assert_exists(&root, SyntaxKind::opt_select_limit);
+
+            let (new_root, _) = get_ts_tree_and_range_map(input, &root);
+            assert_not_exists(&new_root, SyntaxKind::opt_select_limit);
         }
     }
 


### PR DESCRIPTION
## Summary 

`select_limit` および `opt_select_limit` を削除対象のノードに入れました

`select_limit` は limit_clause や offset clause を含むノードで、 `opt_select_limit` はそれをラップしている要素です。 select 文のうち、 for_locking_clause の後にlimit句、 offset 句をで利用されています。

[select_limit](https://github.com/postgres/postgres/blob/e2809e3a1015697832ee4d37b75ba1cd0caac0f0/src/backend/parser/gram.y#L13272-L13301):
```
select_limit:
    limit_clause offset_clause
    | offset_clause limit_clause
    | limit_clause
    | offset_clause
;
```

[opt_select_limit](https://github.com/postgres/postgres/blob/e2809e3a1015697832ee4d37b75ba1cd0caac0f0/src/backend/parser/gram.y#L13303-L13306): 
```
opt_select_limit:
			select_limit						{ $$ = $1; }
			| /* EMPTY */						{ $$ = NULL; }
		;
```

利用箇所：
- https://github.com/postgres/postgres/blob/e2809e3a1015697832ee4d37b75ba1cd0caac0f0/src/backend/parser/gram.y#L12860
- https://github.com/postgres/postgres/blob/e2809e3a1015697832ee4d37b75ba1cd0caac0f0/src/backend/parser/gram.y#L12892
