### PR TITLE
Remove: opt_select_limit, opt_sort_clause

### DIFF
--- a/crates/postgresql-cst-parser/src/tree_sitter/convert.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter/convert.rs
@@ -192,7 +192,8 @@ fn walk_and_build(
                     | SyntaxKind::simple_select
                     | SyntaxKind::select_clause
                     | SyntaxKind::opt_select_limit
-                    | SyntaxKind::opt_target_list => {
+                    | SyntaxKind::opt_target_list
+                    | SyntaxKind::opt_sort_clause => {
                         // [Node: Removal]
                         //
                         // Ignore current node, and continue building its children.
@@ -289,6 +290,16 @@ FROM
 
             let (new_root, _) = get_ts_tree_and_range_map(input, &root);
             assert_not_exists(&new_root, SyntaxKind::opt_select_limit);
+        }
+
+        #[test]
+        fn no_opt_sort_clause() {
+            let input = "select a from t order by a desc limit 5;";
+            let root = cst::parse(input).unwrap();
+            assert_exists(&root, SyntaxKind::opt_sort_clause);
+
+            let (new_root, _) = get_ts_tree_and_range_map(input, &root);
+            assert_not_exists(&new_root, SyntaxKind::opt_sort_clause);
         }
     }
 

--- a/crates/postgresql-cst-parser/src/tree_sitter/convert.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter/convert.rs
@@ -191,6 +191,7 @@ fn walk_and_build(
                     | SyntaxKind::select_no_parens
                     | SyntaxKind::simple_select
                     | SyntaxKind::select_clause
+                    | SyntaxKind::opt_select_limit
                     | SyntaxKind::opt_target_list => {
                         // [Node: Removal]
                         //
@@ -278,6 +279,16 @@ FROM
 
             let (new_root, _) = get_ts_tree_and_range_map(input, &root);
             assert_not_exists(&new_root, SyntaxKind::opt_target_list);
+        }
+
+        #[test]
+        fn no_opt_select_limit() {
+            let input = "select a from t for update limit 5 offset 5;";
+            let root = cst::parse(input).unwrap();
+            assert_exists(&root, SyntaxKind::opt_select_limit);
+
+            let (new_root, _) = get_ts_tree_and_range_map(input, &root);
+            assert_not_exists(&new_root, SyntaxKind::opt_select_limit);
         }
     }
 


### PR DESCRIPTION
## Summary

`opt_select_limit` と `opt_sort_clause` を削除対象のノードに追加しました

- [opt_select_limit](https://github.com/postgres/postgres/blob/e2809e3a1015697832ee4d37b75ba1cd0caac0f0/src/backend/parser/gram.y#L13303-L13306)
- [opt_sort_clause](https://github.com/postgres/postgres/blob/e2809e3a1015697832ee4d37b75ba1cd0caac0f0/src/backend/parser/gram.y#L13237-L13240)