### PR TITLE
Remove select_limit node

### DIFF
--- a/crates/postgresql-cst-parser/src/tree_sitter/convert.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter/convert.rs
@@ -193,7 +193,8 @@ fn walk_and_build(
                     | SyntaxKind::select_clause
                     | SyntaxKind::opt_select_limit
                     | SyntaxKind::opt_target_list
-                    | SyntaxKind::opt_sort_clause => {
+                    | SyntaxKind::opt_sort_clause
+                    | SyntaxKind::select_limit => {
                         // [Node: Removal]
                         //
                         // Ignore current node, and continue building its children.
@@ -300,6 +301,16 @@ FROM
 
             let (new_root, _) = get_ts_tree_and_range_map(input, &root);
             assert_not_exists(&new_root, SyntaxKind::opt_sort_clause);
+        }
+
+        #[test]
+        fn no_select_limit() {
+            let input = "select a from t limit 5;";
+            let root = cst::parse(input).unwrap();
+            assert_exists(&root, SyntaxKind::select_limit);
+
+            let (new_root, _) = get_ts_tree_and_range_map(input, &root);
+            assert_not_exists(&new_root, SyntaxKind::select_limit);
         }
     }
 


### PR DESCRIPTION
## Summary

select_limit を削除対象のノードに加えました。

select_limit は子要素に limit_clause と offset_clause を持ちます。この変更により、 limit_clause と offset_clause は from_clause や where_clause と同じ階層に並ぶようになります。

https://github.com/postgres/postgres/blob/e2809e3a1015697832ee4d37b75ba1cd0caac0f0/src/backend/parser/gram.y#L13272-L13301