### PR TITLE
(tree-sitter module) flatten cte_list, name_list

### DIFF
--- a/crates/postgresql-cst-parser/src/tree_sitter/convert.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter/convert.rs
@@ -147,7 +147,8 @@ fn walk_and_build(
                     | SyntaxKind::group_by_list
                     | SyntaxKind::sortby_list
                     | SyntaxKind::qualified_name_list
-                    | SyntaxKind::for_locking_items) => {
+                    | SyntaxKind::for_locking_items
+                    | SyntaxKind::cte_list) => {
                         if parent_kind == child_kind {
                             // [Node: Flatten]
                             //
@@ -425,6 +426,15 @@ FROM
             let (new_root, _) = get_ts_tree_and_range_map(&input, &root);
 
             assert_no_direct_nested_kind(&new_root, SyntaxKind::qualified_name_list);
+        }
+
+        #[test]
+        fn no_nested_cte_list() {
+            let input = "with a as (select 1), b as (select 2) select * from a, b;";
+            let root = cst::parse(input).unwrap();
+            let (new_root, _) = get_ts_tree_and_range_map(&input, &root);
+
+            assert_no_direct_nested_kind(&new_root, SyntaxKind::cte_list);
         }
     }
 }

--- a/crates/postgresql-cst-parser/src/tree_sitter/convert.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter/convert.rs
@@ -148,7 +148,8 @@ fn walk_and_build(
                     | SyntaxKind::sortby_list
                     | SyntaxKind::qualified_name_list
                     | SyntaxKind::for_locking_items
-                    | SyntaxKind::cte_list) => {
+                    | SyntaxKind::cte_list
+                    | SyntaxKind::name_list) => {
                         if parent_kind == child_kind {
                             // [Node: Flatten]
                             //
@@ -435,6 +436,15 @@ FROM
             let (new_root, _) = get_ts_tree_and_range_map(&input, &root);
 
             assert_no_direct_nested_kind(&new_root, SyntaxKind::cte_list);
+        }
+
+        #[test]
+        fn no_nested_name_list() {
+            let input = "with t (a, b) as (select 1) select * from t;";
+            let root = cst::parse(input).unwrap();
+            let (new_root, _) = get_ts_tree_and_range_map(&input, &root);
+
+            assert_no_direct_nested_kind(&new_root, SyntaxKind::name_list);
         }
     }
 }


### PR DESCRIPTION
## Summary
`cte_list`, `name_list` をフラット化しました

`cte_list` は CTE のリスト、 `name_list` は CTE の列名指定等で使われます。

### フラット化
  - `cte_list`: https://github.com/postgres/postgres/blob/ef366b7d7e3e66ca55ce80c9dfa3254ada727754/src/backend/parser/gram.y#L13051-L13054
  - `name_list`: https://github.com/postgres/postgres/blob/ef366b7d7e3e66ca55ce80c9dfa3254ada727754/src/backend/parser/gram.y#L17340-L17344

