### PR TITLE
flatten set_clause_list and set_target_list

### DIFF
--- a/crates/postgresql-cst-parser/src/tree_sitter/convert.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter/convert.rs
@@ -149,7 +149,8 @@ fn walk_and_build(
                     | SyntaxKind::qualified_name_list
                     | SyntaxKind::for_locking_items
                     | SyntaxKind::cte_list
-                    | SyntaxKind::name_list) => {
+                    | SyntaxKind::name_list
+                    | SyntaxKind::set_clause_list) => {
                         if parent_kind == child_kind {
                             // [Node: Flatten]
                             //
@@ -445,6 +446,15 @@ FROM
             let (new_root, _) = get_ts_tree_and_range_map(&input, &root);
 
             assert_no_direct_nested_kind(&new_root, SyntaxKind::name_list);
+        }
+
+        #[test]
+        fn no_nested_set_clause_list() {
+            let input = "update t set a = 1, b = 2, c = 3;";
+            let root = cst::parse(input).unwrap();
+            let (new_root, _) = get_ts_tree_and_range_map(&input, &root);
+
+            assert_no_direct_nested_kind(&new_root, SyntaxKind::set_clause_list);
         }
     }
 }

--- a/crates/postgresql-cst-parser/src/tree_sitter/convert.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter/convert.rs
@@ -150,7 +150,8 @@ fn walk_and_build(
                     | SyntaxKind::for_locking_items
                     | SyntaxKind::cte_list
                     | SyntaxKind::name_list
-                    | SyntaxKind::set_clause_list) => {
+                    | SyntaxKind::set_clause_list
+                    | SyntaxKind::set_target_list) => {
                         if parent_kind == child_kind {
                             // [Node: Flatten]
                             //
@@ -455,6 +456,15 @@ FROM
             let (new_root, _) = get_ts_tree_and_range_map(&input, &root);
 
             assert_no_direct_nested_kind(&new_root, SyntaxKind::set_clause_list);
+        }
+
+        #[test]
+        fn no_nested_set_target_list() {
+            let input = "update t set (a, b, c) = (1, 2, 3) where id = 1;";
+            let root = cst::parse(input).unwrap();
+            let (new_root, _) = get_ts_tree_and_range_map(&input, &root);
+
+            assert_no_direct_nested_kind(&new_root, SyntaxKind::set_target_list);
         }
     }
 }


### PR DESCRIPTION
## Summary

1. `set_clause_list` をフラット化しました
2. `set_target_list` をフラット化しました

### 1. set_clause_list
`set_clause_list` は、UPDATE 文における SET キーワード以降の部分（`c1 = 1, c2 = 2, c3 = 3`）にあたり、カラムに値を指定する箇所です。

```sql
UPDATE t SET c1 = 1, c2 = 2, c3 = 3 WHERE a=1;
```

```yacc
set_clause_list:
			set_clause							{ $$ = $1; }
			| set_clause_list ',' set_clause	{ $$ = list_concat($1,$3); }
		;
```
https://github.com/postgres/postgres/blob/6389db23209a3a9b99759b26fbd26a9da5693116/src/backend/parser/gram.y#L12514-L12517

### 2. set_target_list
`set_target_list` は、UPDATE 文の SET 句において複数カラムへの同時代入をする際に利用される構文です。

```sql
UPDATE t SET (c1, c2, c3) = (1, 2, 3) WHERE a=1;
```

```yacc
set_target_list:
			set_target								{ $$ = list_make1($1); }
			| set_target_list ',' set_target		{ $$ = lappend($1,$3); }
		;
```
https://github.com/postgres/postgres/blob/6389db23209a3a9b99759b26fbd26a9da5693116/src/backend/parser/gram.y#L12559-L12562