### PR TITLE
flatten insert_column_list ,index_params, and values_clause

### DIFF
--- a/crates/postgresql-cst-parser/src/tree_sitter/convert.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter/convert.rs
@@ -151,7 +151,9 @@ fn walk_and_build(
                     | SyntaxKind::cte_list
                     | SyntaxKind::name_list
                     | SyntaxKind::set_clause_list
-                    | SyntaxKind::set_target_list) => {
+                    | SyntaxKind::set_target_list
+                    | SyntaxKind::insert_column_list
+                    | SyntaxKind::index_params) => {
                         if parent_kind == child_kind {
                             // [Node: Flatten]
                             //
@@ -465,6 +467,24 @@ FROM
             let (new_root, _) = get_ts_tree_and_range_map(&input, &root);
 
             assert_no_direct_nested_kind(&new_root, SyntaxKind::set_target_list);
+        }
+
+        #[test]
+        fn no_nested_insert_column_list() {
+            let input = "insert into t (a, b, c) values (1, 2, 3);";
+            let root = cst::parse(input).unwrap();
+            let (new_root, _) = get_ts_tree_and_range_map(&input, &root);
+
+            assert_no_direct_nested_kind(&new_root, SyntaxKind::insert_column_list);
+        }
+
+        #[test]
+        fn no_nested_index_params() {
+            let input = "insert into t (a, b, c) values (1, 2, 3) on conflict (a, b) do nothing;";
+            let root = cst::parse(input).unwrap();
+            let (new_root, _) = get_ts_tree_and_range_map(&input, &root);
+
+            assert_no_direct_nested_kind(&new_root, SyntaxKind::index_params);
         }
     }
 }

--- a/crates/postgresql-cst-parser/src/tree_sitter/convert.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter/convert.rs
@@ -153,7 +153,8 @@ fn walk_and_build(
                     | SyntaxKind::set_clause_list
                     | SyntaxKind::set_target_list
                     | SyntaxKind::insert_column_list
-                    | SyntaxKind::index_params) => {
+                    | SyntaxKind::index_params
+                    | SyntaxKind::values_clause) => {
                         if parent_kind == child_kind {
                             // [Node: Flatten]
                             //
@@ -485,6 +486,15 @@ FROM
             let (new_root, _) = get_ts_tree_and_range_map(&input, &root);
 
             assert_no_direct_nested_kind(&new_root, SyntaxKind::index_params);
+        }
+
+        #[test]
+        fn no_nested_values_clause() {
+            let input = "values (1,2,3), (4,5,6), (7,8,9);";
+            let root = cst::parse(input).unwrap();
+            let (new_root, _) = get_ts_tree_and_range_map(&input, &root);
+
+            assert_no_direct_nested_kind(&new_root, SyntaxKind::values_clause);
         }
     }
 }


### PR DESCRIPTION
## Summary
`insert_column_list`, `index_params`, `values_clause` をフラット化しました

## insert_column_list
insert 文のカラム名リストにあたる要素
```sql
-- `a, b, c` の部分が該当
INSERT INTO tbl (a, b, c) VALUES (1, 2, 3);
```

```yacc
insert_column_list:
			insert_column_item
					{ $$ = list_make1($1); }
			| insert_column_list ',' insert_column_item
					{ $$ = lappend($1, $3); }
		;
```
https://github.com/postgres/postgres/blob/b225c5e76ed1053e505e392423b0dab065a3b813/src/backend/parser/gram.y#L12306-L12311

## index_params
インデックス定義を複数並べる場合に利用される要素

```sql
-- insert では、 on conflict で登場
-- on conflict の後の a, b の部分が該当
INSERT INTO tbl (a, b, c) VALUES (1, 2, 3)
ON CONFLICT (a, b) DO NOTHING;
```

```yacc
index_params:	index_elem							{ $$ = list_make1($1); }
			| index_params ',' index_elem			{ $$ = lappend($1, $3); }
		;
```
https://github.com/postgres/postgres/blob/b225c5e76ed1053e505e392423b0dab065a3b813/src/backend/parser/gram.y#L8267-L8269

## values_clause
values 句で 複数の列を書く場合に入れ子になる要素
最も内側のものだけ values キーワードが挟まる点でほかのリストと異なる構造だが、フラット化しても問題なし

```sql
values (1,2,3), (4,5,6), (7,8,9);
```

```yacc
values_clause:
			VALUES '(' expr_list ')'
				{
					SelectStmt *n = makeNode(SelectStmt);


					n->stmt_location = @1;
					n->valuesLists = list_make1($3);
					$$ = (Node *) n;
				}
			| values_clause ',' '(' expr_list ')'
				{
					SelectStmt *n = (SelectStmt *) $1;


					n->valuesLists = lappend(n->valuesLists, $4);
					$$ = (Node *) n;
				}
		;
```
https://github.com/postgres/postgres/blob/b225c5e76ed1053e505e392423b0dab065a3b813/src/backend/parser/gram.y#L13588-L13604
