### PR TITLE
select_no_parens ノードを残すように変更

### DIFF
--- a/crates/postgresql-cst-parser/src/tree_sitter/convert.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter/convert.rs
@@ -195,7 +195,6 @@ fn walk_and_build(
                     | SyntaxKind::stmtmulti
                     | SyntaxKind::toplevel_stmt
                     | SyntaxKind::stmt
-                    | SyntaxKind::select_no_parens
                     | SyntaxKind::simple_select
                     | SyntaxKind::select_clause
                     | SyntaxKind::opt_select_limit


### PR DESCRIPTION
## Summay
tree-sitter モジュールの変換処理において削除対象としていた `select_no_parens` ノードを残すように変更しました
（削除対象ノードから外しました）