### PR TITLE
Flatten TableFuncElementList (including test improvement)

### DIFF
--- a/crates/postgresql-cst-parser/src/tree_sitter/convert.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter/convert.rs
@@ -326,7 +326,9 @@ FROM
             cst,
             syntax_kind::SyntaxKind,
             tree_sitter::{
-                assert_util::{assert_no_direct_nested_kind, assert_node_count},
+                assert_util::{
+                    assert_direct_nested_kind, assert_no_direct_nested_kind, assert_node_count,
+                },
                 convert::get_ts_tree_and_range_map,
             },
         };
@@ -337,6 +339,7 @@ FROM
 
             let root = cst::parse(input).unwrap();
             assert_node_count(&root, SyntaxKind::target_list, 3);
+            assert_direct_nested_kind(&root, SyntaxKind::target_list);
 
             let (new_root, _) = get_ts_tree_and_range_map(input, &root);
             assert_node_count(&new_root, SyntaxKind::target_list, 1);
@@ -347,8 +350,9 @@ FROM
         fn no_nested_stmtmulti() {
             let input = "select a,b,c;\nselect d,e from t;";
             let root = cst::parse(input).unwrap();
-            let (new_root, _) = get_ts_tree_and_range_map(input, &root);
+            assert_direct_nested_kind(&root, SyntaxKind::stmtmulti);
 
+            let (new_root, _) = get_ts_tree_and_range_map(input, &root);
             assert_no_direct_nested_kind(&new_root, SyntaxKind::stmtmulti);
         }
 
@@ -356,8 +360,9 @@ FROM
         fn no_nested_from_list() {
             let input = "select * from t1, t2;";
             let root = cst::parse(input).unwrap();
-            let (new_root, _) = get_ts_tree_and_range_map(input, &root);
+            assert_direct_nested_kind(&root, SyntaxKind::from_list);
 
+            let (new_root, _) = get_ts_tree_and_range_map(input, &root);
             assert_no_direct_nested_kind(&new_root, SyntaxKind::from_list);
         }
 
@@ -366,8 +371,9 @@ FROM
             let input =
                 "select t.a, t.b.c, t1.*, a[1], a[4][5], a[2:5], a[3].b, a[3][4].b, a[3:5].b;";
             let root = cst::parse(input).unwrap();
-            let (new_root, _) = get_ts_tree_and_range_map(input, &root);
+            assert_direct_nested_kind(&root, SyntaxKind::indirection);
 
+            let (new_root, _) = get_ts_tree_and_range_map(input, &root);
             assert_no_direct_nested_kind(&new_root, SyntaxKind::indirection);
         }
 
@@ -375,8 +381,9 @@ FROM
         fn no_nested_expr_list() {
             let input = "select a from t where a in (1,2,3);";
             let root = cst::parse(input).unwrap();
-            let (new_root, _) = get_ts_tree_and_range_map(input, &root);
+            assert_direct_nested_kind(&root, SyntaxKind::expr_list);
 
+            let (new_root, _) = get_ts_tree_and_range_map(input, &root);
             assert_no_direct_nested_kind(&new_root, SyntaxKind::expr_list);
         }
 
@@ -384,8 +391,9 @@ FROM
         fn no_nested_func_arg_list() {
             let input = "select func(1, 2, func2(3, 4), 5);";
             let root = cst::parse(input).unwrap();
-            let (new_root, _) = get_ts_tree_and_range_map(input, &root);
+            assert_direct_nested_kind(&root, SyntaxKind::func_arg_list);
 
+            let (new_root, _) = get_ts_tree_and_range_map(input, &root);
             assert_no_direct_nested_kind(&new_root, SyntaxKind::func_arg_list);
         }
 
@@ -393,8 +401,9 @@ FROM
         fn no_nested_when_clause_list() {
             let input = "select case when a then b when c then d when e then f else g end;";
             let root = cst::parse(input).unwrap();
-            let (new_root, _) = get_ts_tree_and_range_map(input, &root);
+            assert_direct_nested_kind(&root, SyntaxKind::when_clause_list);
 
+            let (new_root, _) = get_ts_tree_and_range_map(input, &root);
             assert_no_direct_nested_kind(&new_root, SyntaxKind::when_clause_list);
         }
 
@@ -402,8 +411,9 @@ FROM
         fn no_nested_sortby_list() {
             let input = "select * from t order by a, b, c;";
             let root = cst::parse(input).unwrap();
-            let (new_root, _) = get_ts_tree_and_range_map(input, &root);
+            assert_direct_nested_kind(&root, SyntaxKind::sortby_list);
 
+            let (new_root, _) = get_ts_tree_and_range_map(input, &root);
             assert_no_direct_nested_kind(&new_root, SyntaxKind::sortby_list);
         }
 
@@ -411,8 +421,9 @@ FROM
         fn no_nested_groupby_list() {
             let input = "select a, b, c from t group by a, b, c;";
             let root = cst::parse(input).unwrap();
-            let (new_root, _) = get_ts_tree_and_range_map(input, &root);
+            assert_direct_nested_kind(&root, SyntaxKind::group_by_list);
 
+            let (new_root, _) = get_ts_tree_and_range_map(input, &root);
             assert_no_direct_nested_kind(&new_root, SyntaxKind::group_by_list);
         }
 
@@ -420,8 +431,9 @@ FROM
         fn no_nested_for_locking_items() {
             let input = "select * from t1, t2 for update of t1 for update of t2;";
             let root = cst::parse(input).unwrap();
-            let (new_root, _) = get_ts_tree_and_range_map(input, &root);
+            assert_direct_nested_kind(&root, SyntaxKind::for_locking_items);
 
+            let (new_root, _) = get_ts_tree_and_range_map(input, &root);
             assert_no_direct_nested_kind(&new_root, SyntaxKind::for_locking_items);
         }
 
@@ -429,8 +441,9 @@ FROM
         fn no_nested_qualified_name_list() {
             let input = "select a from t for update of t.a, t.b;";
             let root = cst::parse(input).unwrap();
-            let (new_root, _) = get_ts_tree_and_range_map(input, &root);
+            assert_direct_nested_kind(&root, SyntaxKind::qualified_name_list);
 
+            let (new_root, _) = get_ts_tree_and_range_map(input, &root);
             assert_no_direct_nested_kind(&new_root, SyntaxKind::qualified_name_list);
         }
 
@@ -438,8 +451,9 @@ FROM
         fn no_nested_cte_list() {
             let input = "with a as (select 1), b as (select 2) select * from a, b;";
             let root = cst::parse(input).unwrap();
-            let (new_root, _) = get_ts_tree_and_range_map(input, &root);
+            assert_direct_nested_kind(&root, SyntaxKind::cte_list);
 
+            let (new_root, _) = get_ts_tree_and_range_map(input, &root);
             assert_no_direct_nested_kind(&new_root, SyntaxKind::cte_list);
         }
 
@@ -447,8 +461,9 @@ FROM
         fn no_nested_name_list() {
             let input = "with t (a, b) as (select 1) select * from t;";
             let root = cst::parse(input).unwrap();
-            let (new_root, _) = get_ts_tree_and_range_map(input, &root);
+            assert_direct_nested_kind(&root, SyntaxKind::name_list);
 
+            let (new_root, _) = get_ts_tree_and_range_map(input, &root);
             assert_no_direct_nested_kind(&new_root, SyntaxKind::name_list);
         }
 
@@ -456,8 +471,9 @@ FROM
         fn no_nested_set_clause_list() {
             let input = "update t set a = 1, b = 2, c = 3;";
             let root = cst::parse(input).unwrap();
-            let (new_root, _) = get_ts_tree_and_range_map(input, &root);
+            assert_direct_nested_kind(&root, SyntaxKind::set_clause_list);
 
+            let (new_root, _) = get_ts_tree_and_range_map(input, &root);
             assert_no_direct_nested_kind(&new_root, SyntaxKind::set_clause_list);
         }
 
@@ -465,8 +481,9 @@ FROM
         fn no_nested_set_target_list() {
             let input = "update t set (a, b, c) = (1, 2, 3) where id = 1;";
             let root = cst::parse(input).unwrap();
-            let (new_root, _) = get_ts_tree_and_range_map(input, &root);
+            assert_direct_nested_kind(&root, SyntaxKind::set_target_list);
 
+            let (new_root, _) = get_ts_tree_and_range_map(input, &root);
             assert_no_direct_nested_kind(&new_root, SyntaxKind::set_target_list);
         }
 
@@ -474,8 +491,9 @@ FROM
         fn no_nested_insert_column_list() {
             let input = "insert into t (a, b, c) values (1, 2, 3);";
             let root = cst::parse(input).unwrap();
-            let (new_root, _) = get_ts_tree_and_range_map(input, &root);
+            assert_direct_nested_kind(&root, SyntaxKind::insert_column_list);
 
+            let (new_root, _) = get_ts_tree_and_range_map(input, &root);
             assert_no_direct_nested_kind(&new_root, SyntaxKind::insert_column_list);
         }
 
@@ -483,8 +501,9 @@ FROM
         fn no_nested_index_params() {
             let input = "insert into t (a, b, c) values (1, 2, 3) on conflict (a, b) do nothing;";
             let root = cst::parse(input).unwrap();
-            let (new_root, _) = get_ts_tree_and_range_map(input, &root);
+            assert_direct_nested_kind(&root, SyntaxKind::index_params);
 
+            let (new_root, _) = get_ts_tree_and_range_map(input, &root);
             assert_no_direct_nested_kind(&new_root, SyntaxKind::index_params);
         }
 
@@ -492,8 +511,9 @@ FROM
         fn no_nested_values_clause() {
             let input = "values (1,2,3), (4,5,6), (7,8,9);";
             let root = cst::parse(input).unwrap();
-            let (new_root, _) = get_ts_tree_and_range_map(input, &root);
+            assert_direct_nested_kind(&root, SyntaxKind::values_clause);
 
+            let (new_root, _) = get_ts_tree_and_range_map(input, &root);
             assert_no_direct_nested_kind(&new_root, SyntaxKind::values_clause);
         }
 
@@ -501,8 +521,9 @@ FROM
         fn no_nested_table_func_element_list() {
             let input = "select * from unnest(a) as (x int, y text);";
             let root = cst::parse(input).unwrap();
-            let (new_root, _) = get_ts_tree_and_range_map(input, &root);
+            assert_direct_nested_kind(&root, SyntaxKind::TableFuncElementList);
 
+            let (new_root, _) = get_ts_tree_and_range_map(input, &root);
             assert_no_direct_nested_kind(&new_root, SyntaxKind::TableFuncElementList);
         }
     }

--- a/crates/postgresql-cst-parser/src/tree_sitter/convert.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter/convert.rs
@@ -154,7 +154,8 @@ fn walk_and_build(
                     | SyntaxKind::set_target_list
                     | SyntaxKind::insert_column_list
                     | SyntaxKind::index_params
-                    | SyntaxKind::values_clause) => {
+                    | SyntaxKind::values_clause
+                    | SyntaxKind::TableFuncElementList) => {
                         if parent_kind == child_kind {
                             // [Node: Flatten]
                             //
@@ -494,6 +495,15 @@ FROM
             let (new_root, _) = get_ts_tree_and_range_map(input, &root);
 
             assert_no_direct_nested_kind(&new_root, SyntaxKind::values_clause);
+        }
+
+        #[test]
+        fn no_nested_table_func_element_list() {
+            let input = "select * from unnest(a) as (x int, y text);";
+            let root = cst::parse(input).unwrap();
+            let (new_root, _) = get_ts_tree_and_range_map(input, &root);
+
+            assert_no_direct_nested_kind(&new_root, SyntaxKind::TableFuncElementList);
         }
     }
 }


### PR DESCRIPTION
## Summary

1. `TableFuncElementList` をフラット化しました
2. 変換処理の false-positive を検出できるようテストを改善しました

### 1. フラット化
commit: https://github.com/future-architect/postgresql-cst-parser/pull/29/commits/13a4f5ee02ac8a4de3c36c84489ad72ceae8a8e0

`TableFuncElementList` はテーブル関数の名前付きエイリアスで、列の型を明示する場合に使われる構文です。
```bison
TableFuncElementList:
			TableFuncElement
				{
					$$ = list_make1($1);
				}
			| TableFuncElementList ',' TableFuncElement
				{
					$$ = lappend($1, $3);
				}
		;
```
source: https://github.com/postgres/postgres/blob/641f20d4c433b66df2928408fb2b44bd165c2329/src/backend/parser/gram.y#L14159-L14168

このリストがネストしないような変換処理を加えました。

利用例：
```sql
select * from unnest(a) as (x int, y text);
```
```
as (x int, y text)
^^^^^^^^^^^^^^^^^^
...
func_alias_clause
-+AS "as"
-+ColId
---+IDENT "t"
-+LParen "("
-+TableFuncElementList // here
---+TableFuncElement
-----+ColId
-------+IDENT "x"
-----+Typename
-------+SimpleTypename
---------+Numeric
-----------+INT_P "int"
---+Comma ","
---+TableFuncElement
-----+ColId
-------+IDENT "y"
-----+Typename
-------+SimpleTypename
---------+GenericType
-----------+type_function_name
-------------+unreserved_keyword
---------------+TEXT_P "text"
-+RParen ")"
...
```

### 2. テスト改善
commit: https://github.com/future-architect/postgresql-cst-parser/pull/29/commits/5a97979193c816d43add19a0f31ba7ba6adb6e01

これまで、flatten 系のテストは木の変換後にネストしたノードが無いことを確認しているのみでした。そのためそもそも対象ノードがネストしていないパターンがあっても気づけない構成になっていました。

今回の変更では、変換前の木の構造に対するチェックを入れることで、このモジュールで実行される変換処理が意味のあるものであることを保証するようにしました。

```rs
#[test]
fn no_nested_table_func_element_list() {
    let input = "select * from unnest(a) as (x int, y text);";
    let root = cst::parse(input).unwrap();

    // フラット化対象があることを確認 （今回の変更で追加したもの）
    assert_direct_nested_kind(&root, SyntaxKind::TableFuncElementList);

    // 変換処理（テスト対象）
    let (new_root, _) = get_ts_tree_and_range_map(input, &root);

    // 本命の assert
    assert_no_direct_nested_kind(&new_root, SyntaxKind::TableFuncElementList);
}
```
