### PR TITLE
feat: add new apis for linter

### DIFF
--- a/crates/parser-generator/src/parser_generator/lalr.rs
+++ b/crates/parser-generator/src/parser_generator/lalr.rs
@@ -250,7 +250,8 @@ impl Lalr {
                 .map(|c| id_mapper.to_component_id(&c))
                 .or_else(|| {
                     rule.components
-                        .iter().rfind(|c| matches!(c, Component::Terminal(_)))
+                        .iter()
+                        .rfind(|c| matches!(c, Component::Terminal(_)))
                         .map(|c| id_mapper.to_component_id(c))
                 })
                 .and_then(|component_id| assoc[component_id.0 as usize].clone());

--- a/crates/parser-generator/src/parser_generator/lexer/generated.rs
+++ b/crates/parser-generator/src/parser_generator/lexer/generated.rs
@@ -5,11 +5,11 @@
 use std::collections::HashMap;
 
 use super::{
+    Lexer, NAMEDATALEN, ParserError, TokenKind, Yylval,
     lexer_ported::{
         get_char_by_byte_pos, is_highbit_set, is_utf16_surrogate_first, is_utf16_surrogate_second,
         surrogate_pair_to_codepoint,
     },
-    Lexer, ParserError, TokenKind, Yylval, NAMEDATALEN,
 };
 
 macro_rules! ereport {
@@ -4027,11 +4027,18 @@ impl Lexer {
 
                         self.set_yylloc();
                         if !STANDARD_CONFORMING_STRINGS {
-                            ereport!(self, ERROR,
-								(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-								 errmsg("unsafe use of string constant with Unicode escapes"),
-								 errdetail("String constants with Unicode escapes cannot be used when standard_conforming_strings is off."),
-								 self.lexer_errposition()));
+                            ereport!(
+                                self,
+                                ERROR,
+                                (
+                                    errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+                                    errmsg("unsafe use of string constant with Unicode escapes"),
+                                    errdetail(
+                                        "String constants with Unicode escapes cannot be used when standard_conforming_strings is off."
+                                    ),
+                                    self.lexer_errposition()
+                                )
+                            );
                         }
                         self.begin(State::xus);
                         self.literal.clear();
@@ -5370,11 +5377,18 @@ impl Lexer {
 
                         self.set_yylloc();
                         if !STANDARD_CONFORMING_STRINGS {
-                            ereport!(self, ERROR,
-								(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-								 errmsg("unsafe use of string constant with Unicode escapes"),
-								 errdetail("String constants with Unicode escapes cannot be used when standard_conforming_strings is off."),
-								 self.lexer_errposition()));
+                            ereport!(
+                                self,
+                                ERROR,
+                                (
+                                    errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+                                    errmsg("unsafe use of string constant with Unicode escapes"),
+                                    errdetail(
+                                        "String constants with Unicode escapes cannot be used when standard_conforming_strings is off."
+                                    ),
+                                    self.lexer_errposition()
+                                )
+                            );
                         }
                         self.begin(State::xus);
                         self.literal.clear();

--- a/crates/postgresql-cst-parser/src/lexer/lexer_ported.rs
+++ b/crates/postgresql-cst-parser/src/lexer/lexer_ported.rs
@@ -1,5 +1,5 @@
 /// Ported sources from PostgreSQL
-use super::{Lexer, Token, TokenKind, Yylval, parser_error::ParserError};
+use super::{parser_error::ParserError, Lexer, Token, TokenKind, Yylval};
 
 pub fn is_highbit_set(c: char) -> u8 {
     (c as u8) & 0x80

--- a/crates/postgresql-cst-parser/src/lexer/util.rs
+++ b/crates/postgresql-cst-parser/src/lexer/util.rs
@@ -1,8 +1,8 @@
 #![allow(dead_code)]
 
 use super::{
+    generated::{get_keyword_map, State},
     Lexer, ScanReport, Yylval,
-    generated::{State, get_keyword_map},
 };
 
 impl Lexer {

--- a/crates/postgresql-cst-parser/src/tree_sitter.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter.rs
@@ -98,6 +98,24 @@ impl std::fmt::Display for Range {
     }
 }
 
+impl Range {
+    pub fn extended_by(&self, other: &Self) -> Self {
+        Range {
+            start_byte: self.start_byte.min(other.start_byte),
+            end_byte: self.end_byte.max(other.end_byte),
+
+            start_position: Point {
+                row: self.start_position.row.min(other.start_position.row),
+                column: self.start_position.column.min(other.start_position.column),
+            },
+            end_position: Point {
+                row: self.end_position.row.max(other.end_position.row),
+                column: self.end_position.column.max(other.end_position.column),
+            },
+        }
+    }
+}
+
 impl<'a> Node<'a> {
     pub fn walk(&self) -> TreeCursor<'a> {
         TreeCursor {
@@ -141,6 +159,20 @@ impl<'a> Node<'a> {
             node.children_with_tokens().count()
         } else {
             0
+        }
+    }
+
+    pub fn children(&self) -> Vec<Node<'a>> {
+        if let Some(node) = self.node_or_token.as_node() {
+            node.children_with_tokens()
+                .map(|node| Node {
+                    input: self.input,
+                    range_map: Rc::clone(&self.range_map),
+                    node_or_token: node,
+                })
+                .collect()
+        } else {
+            vec![]
         }
     }
 

--- a/crates/postgresql-cst-parser/src/tree_sitter.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter.rs
@@ -210,7 +210,7 @@ impl<'a> Node<'a> {
 
     /// Return the rightmost token in the subtree of this node
     /// this is not tree-sitter's API
-    pub fn last_token(&self) -> Option<Node<'a>> {
+    pub fn last_node(&self) -> Option<Node<'a>> {
         match &self.node_or_token {
             NodeOrToken::Node(node) => node.last_token().map(|token| Node {
                 input: self.input,
@@ -568,7 +568,7 @@ from
     }
 
     #[test]
-    fn test_last_token_returns_rightmost_token() {
+    fn test_last_node_returns_rightmost_node() {
         let src = "SELECT u.*, (v).id, name;";
         let tree = parse(src).unwrap();
         let root = tree.root_node();
@@ -578,9 +578,9 @@ from
             .find(|node| node.kind() == SyntaxKind::target_list)
             .expect("should find target_list");
 
-        // last token of the target_list is returned
-        let last_token = target_list.last_token().expect("should have last token");
-        assert_eq!(last_token.text(), "name");
+        // last node of the target_list is returned
+        let last_node = target_list.last_node().expect("should have last node");
+        assert_eq!(last_node.text(), "name");
 
         let target_els = target_list
             .children()
@@ -588,14 +588,14 @@ from
             .filter(|node| node.kind() == SyntaxKind::target_el)
             .collect::<Vec<_>>();
 
-        let mut last_tokens = target_els
+        let mut last_nodes = target_els
             .iter()
-            .map(|node| node.last_token().expect("should have last token"));
+            .map(|node| node.last_node().expect("should have last node"));
 
-        // last token of each target_el is returned
-        assert_eq!(last_tokens.next().unwrap().text(), "*");
-        assert_eq!(last_tokens.next().unwrap().text(), "id");
-        assert_eq!(last_tokens.next().unwrap().text(), "name");
-        assert!(last_tokens.next().is_none());
+        // last node of each target_el is returned
+        assert_eq!(last_nodes.next().unwrap().text(), "*");
+        assert_eq!(last_nodes.next().unwrap().text(), "id");
+        assert_eq!(last_nodes.next().unwrap().text(), "name");
+        assert!(last_nodes.next().is_none());
     }
 }

--- a/crates/postgresql-cst-parser/src/tree_sitter.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter.rs
@@ -186,6 +186,16 @@ impl<'a> Node<'a> {
             })
     }
 
+    pub fn prev_sibling(&self) -> Option<Node<'a>> {
+        self.node_or_token
+            .prev_sibling_or_token()
+            .map(|sibling| Node {
+                input: self.input,
+                range_map: Rc::clone(&self.range_map),
+                node_or_token: sibling,
+            })
+    }
+
     pub fn parent(&self) -> Option<Node<'a>> {
         self.node_or_token.parent().map(|parent| Node {
             input: self.input,
@@ -239,6 +249,15 @@ impl<'a> TreeCursor<'a> {
 
     pub fn goto_next_sibling(&mut self) -> bool {
         if let Some(sibling) = self.node_or_token.next_sibling_or_token() {
+            self.node_or_token = sibling;
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn goto_prev_sibling(&mut self) -> bool {
+        if let Some(sibling) = self.node_or_token.prev_sibling_or_token() {
             self.node_or_token = sibling;
             true
         } else {

--- a/crates/postgresql-cst-parser/src/tree_sitter.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter.rs
@@ -180,6 +180,34 @@ impl<'a> Node<'a> {
         }
     }
 
+    /// Returns the first child element of this node.
+    /// this is not tree-sitter's API
+    pub fn first_child(&self) -> Option<Node<'a>> {
+        if let Some(node) = self.node_or_token.as_node() {
+            node.first_child_or_token().map(|child| Node {
+                input: self.input,
+                range_map: Rc::clone(&self.range_map),
+                node_or_token: child,
+            })
+        } else {
+            None
+        }
+    }
+
+    /// Returns the last child element of this node.
+    /// this is not tree-sitter's API
+    pub fn last_child(&self) -> Option<Node<'a>> {
+        if let Some(node) = self.node_or_token.as_node() {
+            node.last_child_or_token().map(|child| Node {
+                input: self.input,
+                range_map: Rc::clone(&self.range_map),
+                node_or_token: child,
+            })
+        } else {
+            None
+        }
+    }
+
     pub fn next_sibling(&self) -> Option<Node<'a>> {
         self.node_or_token
             .next_sibling_or_token()
@@ -212,7 +240,7 @@ impl<'a> Node<'a> {
         matches!(self.kind(), SyntaxKind::C_COMMENT | SyntaxKind::SQL_COMMENT)
     }
 
-    /// Return the rightmost token in the subtree of this node
+    /// Returns the rightmost token in the subtree of this node.
     /// this is not tree-sitter's API
     pub fn last_node(&self) -> Option<Node<'a>> {
         match &self.node_or_token {

--- a/crates/postgresql-cst-parser/src/tree_sitter.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter.rs
@@ -114,6 +114,10 @@ impl Range {
             },
         }
     }
+
+    pub fn is_adjacent(&self, other: &Self) -> bool {
+        self.end_byte == other.start_byte || self.start_byte == other.end_byte
+    }
 }
 
 impl<'a> Node<'a> {

--- a/crates/postgresql-cst-parser/src/tree_sitter.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter.rs
@@ -293,40 +293,22 @@ impl<'a> Node<'a> {
     /// including this node and tokens.
     /// this is not tree-sitter's API
     pub fn descendants(&self) -> impl Iterator<Item = Node<'a>> + '_ {
-        struct Descendants<'a> {
-            iter: Box<dyn Iterator<Item = Node<'a>> + 'a>,
-        }
+        let input = self.input;
+        let range_map = Rc::clone(&self.range_map);
 
-        impl<'a> Iterator for Descendants<'a> {
-            type Item = Node<'a>;
+        let iter: Box<dyn Iterator<Item = Node<'a>> + '_> = match self.node_or_token.as_node() {
+            Some(node) => Box::new(
+                node.descendants_with_tokens()
+                    .map(move |node_or_token| Node {
+                        input,
+                        range_map: Rc::clone(&range_map),
+                        node_or_token,
+                    }),
+            ),
+            None => Box::new(std::iter::once(self.clone())),
+        };
 
-            fn next(&mut self) -> Option<Self::Item> {
-                self.iter.next()
-            }
-        }
-
-        if let Some(node) = self.node_or_token.as_node() {
-            let input = self.input;
-            let range_map = Rc::clone(&self.range_map);
-            Descendants {
-                iter: Box::new(
-                    node.descendants_with_tokens()
-                        .map(move |node_or_token| Node {
-                            input,
-                            range_map: Rc::clone(&range_map),
-                            node_or_token,
-                        }),
-                ),
-            }
-        } else {
-            Descendants {
-                iter: Box::new(std::iter::once(Node {
-                    input: self.input,
-                    range_map: Rc::clone(&self.range_map),
-                    node_or_token: self.node_or_token,
-                })),
-            }
-        }
+        iter
     }
 }
 

--- a/crates/postgresql-cst-parser/src/tree_sitter.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter.rs
@@ -108,18 +108,22 @@ impl std::fmt::Display for Range {
 
 impl Range {
     pub fn extended_by(&self, other: &Self) -> Self {
-        Range {
-            start_byte: self.start_byte.min(other.start_byte),
-            end_byte: self.end_byte.max(other.end_byte),
+        let (start_byte, start_position) = if self.start_byte <= other.start_byte {
+            (self.start_byte, self.start_position.clone())
+        } else {
+            (other.start_byte, other.start_position.clone())
+        };
+        let (end_byte, end_position) = if self.end_byte >= other.end_byte {
+            (self.end_byte, self.end_position.clone())
+        } else {
+            (other.end_byte, other.end_position.clone())
+        };
 
-            start_position: Point {
-                row: self.start_position.row.min(other.start_position.row),
-                column: self.start_position.column.min(other.start_position.column),
-            },
-            end_position: Point {
-                row: self.end_position.row.max(other.end_position.row),
-                column: self.end_position.column.max(other.end_position.column),
-            },
+        Range {
+            start_byte,
+            end_byte,
+            start_position,
+            end_position,
         }
     }
 
@@ -545,6 +549,64 @@ from
         assert_eq!(range.to_string(), "[(5, 0)-(5, 1)]");
 
         assert!(tokens.next().is_none());
+    }
+
+    #[test]
+    fn range_extended_by_keeps_original_positions_across_lines() {
+        let tree = parse("SELECT a,\n  b").unwrap();
+        let root = tree.root_node();
+        let mut tokens = root
+            .descendants()
+            .filter(|node| node.kind() == SyntaxKind::IDENT)
+            .map(|node| (node.text(), node.range()));
+
+        let (_, a_range) = tokens.next().expect("should find a token");
+        let (_, b_range) = tokens.next().expect("should find b token");
+        let extended = a_range.extended_by(&b_range);
+        let expected = super::Range {
+            start_byte: a_range.start_byte,
+            end_byte: b_range.end_byte,
+            start_position: a_range.start_position.clone(),
+            end_position: b_range.end_position.clone(),
+        };
+
+        assert_eq!(extended.start_byte, expected.start_byte);
+        assert_eq!(extended.end_byte, expected.end_byte);
+        assert_eq!(
+            extended.start_position.to_string(),
+            expected.start_position.to_string()
+        );
+        assert_eq!(
+            extended.end_position.to_string(),
+            expected.end_position.to_string()
+        );
+    }
+
+    #[test]
+    fn range_extended_by_is_order_independent() {
+        let tree = parse("SELECT a,\n  b").unwrap();
+        let root = tree.root_node();
+        let mut tokens = root
+            .descendants()
+            .filter(|node| node.kind() == SyntaxKind::IDENT)
+            .map(|node| node.range());
+
+        let a_range = tokens.next().expect("should find a token");
+        let b_range = tokens.next().expect("should find b token");
+
+        let forward = a_range.extended_by(&b_range);
+        let backward = b_range.extended_by(&a_range);
+
+        assert_eq!(forward.start_byte, backward.start_byte);
+        assert_eq!(forward.end_byte, backward.end_byte);
+        assert_eq!(
+            forward.start_position.to_string(),
+            backward.start_position.to_string()
+        );
+        assert_eq!(
+            forward.end_position.to_string(),
+            backward.end_position.to_string()
+        );
     }
 
     #[test]

--- a/crates/postgresql-cst-parser/src/tree_sitter.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter.rs
@@ -250,7 +250,7 @@ impl<'a> Node<'a> {
 
     /// Returns the rightmost token in the subtree of this node.
     /// this is not tree-sitter's API
-    pub fn last_node(&self) -> Option<Node<'a>> {
+    pub fn last_token(&self) -> Option<Node<'a>> {
         match &self.node_or_token {
             NodeOrToken::Node(node) => node.last_token().map(|token| Node {
                 input: self.input,
@@ -631,7 +631,7 @@ from
     }
 
     #[test]
-    fn test_last_node_returns_rightmost_node() {
+    fn test_last_token_returns_rightmost_token() {
         let src = "SELECT u.*, (v).id, name;";
         let tree = parse(src).unwrap();
         let root = tree.root_node();
@@ -641,9 +641,9 @@ from
             .find(|node| node.kind() == SyntaxKind::target_list)
             .expect("should find target_list");
 
-        // last node of the target_list is returned
-        let last_node = target_list.last_node().expect("should have last node");
-        assert_eq!(last_node.text(), "name");
+        // last token of the target_list is returned
+        let last_token = target_list.last_token().expect("should have last token");
+        assert_eq!(last_token.text(), "name");
 
         let target_els = target_list
             .children()
@@ -651,15 +651,15 @@ from
             .filter(|node| node.kind() == SyntaxKind::target_el)
             .collect::<Vec<_>>();
 
-        let mut last_nodes = target_els
+        let mut last_tokens = target_els
             .iter()
-            .map(|node| node.last_node().expect("should have last node"));
+            .map(|node| node.last_token().expect("should have last token"));
 
-        // last node of each target_el is returned
-        assert_eq!(last_nodes.next().unwrap().text(), "*");
-        assert_eq!(last_nodes.next().unwrap().text(), "id");
-        assert_eq!(last_nodes.next().unwrap().text(), "name");
-        assert!(last_nodes.next().is_none());
+        // last token of each target_el is returned
+        assert_eq!(last_tokens.next().unwrap().text(), "*");
+        assert_eq!(last_tokens.next().unwrap().text(), "id");
+        assert_eq!(last_tokens.next().unwrap().text(), "name");
+        assert!(last_tokens.next().is_none());
     }
 
     #[test]

--- a/crates/postgresql-cst-parser/src/tree_sitter.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter.rs
@@ -289,7 +289,8 @@ impl<'a> Node<'a> {
         }
     }
 
-    /// Returns an iterator over all descendant nodes (including tokens)
+    /// Returns an iterator over all nodes in the subtree starting at this node,
+    /// including this node and tokens.
     /// this is not tree-sitter's API
     pub fn descendants(&self) -> impl Iterator<Item = Node<'a>> + '_ {
         struct Descendants<'a> {
@@ -319,7 +320,11 @@ impl<'a> Node<'a> {
             }
         } else {
             Descendants {
-                iter: Box::new(std::iter::empty()),
+                iter: Box::new(std::iter::once(Node {
+                    input: self.input,
+                    range_map: Rc::clone(&self.range_map),
+                    node_or_token: self.node_or_token,
+                })),
             }
         }
     }

--- a/crates/postgresql-cst-parser/src/tree_sitter.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter.rs
@@ -63,6 +63,14 @@ pub struct Node<'a> {
     pub node_or_token: NodeOrToken<'a>,
 }
 
+impl<'a> PartialEq for Node<'a> {
+    fn eq(&self, other: &Self) -> bool {
+        self.node_or_token == other.node_or_token
+    }
+}
+
+impl<'a> Eq for Node<'a> {}
+
 #[derive(Debug, Clone)]
 pub struct TreeCursor<'a> {
     pub input: &'a str,


### PR DESCRIPTION
`tree-sitter` module にいくつかのAPIを追加しました。
https://github.com/future-architect/uroborosql-fmt/pull/215 における利用を想定したものです。

## tree-sitter like API
- `Node::children`
- `Node::prev_sibling`
- `Cursor::goto_prev_sibling`

## `cstree` の機能のラッパー
- `Node::last_token`
  - https://docs.rs/cstree/0.13.0/cstree/syntax/type.SyntaxElement.html#method.last_token
- `Node::next_token`
  - https://docs.rs/cstree/0.13.0/cstree/syntax/struct.ResolvedToken.html#method.next_token
- `Node::descendants`
  - `ResolvedToken::descendants_with_tokens` をラップ
  - https://docs.rs/cstree/0.13.0/cstree/syntax/struct.ResolvedNode.html#method.descendants

## その他

- `Range::extended_by`
- `Range::is_adjacent`
