### PR TITLE
fix warnings

### DIFF
--- a/crates/automata/src/nfa.rs
+++ b/crates/automata/src/nfa.rs
@@ -39,7 +39,7 @@ impl PartialEq for NFAState<'_> {
 
 impl PartialOrd for NFAState<'_> {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.state_id.cmp(&other.state_id))
+        Some(self.cmp(other))
     }
 }
 

--- a/crates/parser-generator/src/parser_generator/lexer/lexer_ported.rs
+++ b/crates/parser-generator/src/parser_generator/lexer/lexer_ported.rs
@@ -162,10 +162,10 @@ pub fn init_tokens(tokens: &mut [Token]) {
     for i in 0..tokens.len() - 1 {
         match &tokens[i].kind {
             TokenKind::KEYWORD(k) if k == "FORMAT" => {
-                if let Some(j) = next_token_index(tokens, i) {
-                    if tokens[j].kind == TokenKind::KEYWORD("JSON".to_string()) {
-                        tokens[i].kind = TokenKind::KEYWORD("FORMAT_LA".to_string());
-                    }
+                if let Some(j) = next_token_index(tokens, i)
+                    && tokens[j].kind == TokenKind::KEYWORD("JSON".to_string())
+                {
+                    tokens[i].kind = TokenKind::KEYWORD("FORMAT_LA".to_string());
                 }
             }
             TokenKind::KEYWORD(k) if k == "NOT" => {

--- a/crates/postgresql-cst-parser/src/cst/lr_parse_state.rs
+++ b/crates/postgresql-cst-parser/src/cst/lr_parse_state.rs
@@ -16,7 +16,7 @@ impl<'a> LRParseState<'a> {
         matches!(self.extras.last(), Some(e) if e.end_byte_pos != self.token.start_byte_pos && e.kind == SyntaxKind::C_COMMENT)
     }
 
-    pub(crate) fn previous_extra(&self) -> Option<&Extra> {
+    pub(crate) fn previous_extra(&self) -> Option<&Extra<'_>> {
         let last_extra = self.extras.last()?;
 
         let stack_end_byte_pos = self

--- a/crates/postgresql-cst-parser/src/tree_sitter.rs
+++ b/crates/postgresql-cst-parser/src/tree_sitter.rs
@@ -47,7 +47,7 @@ impl Tree {
         }
     }
 
-    pub fn root_node(&self) -> Node {
+    pub fn root_node(&self) -> Node<'_> {
         Node {
             input: &self.src,
             range_map: Rc::clone(&self.range_map),


### PR DESCRIPTION
## Summary
rustc と Clippy による Lint で検出されていた箇所を修正しました

1. `mismatched_lifetime_syntaxes` by rustc
    - 暗黙的なライフタイム注釈の明示
    - https://doc.rust-lang.org/stable/nightly-rustc/rustc_lint/lifetime_syntax/static.MISMATCHED_LIFETIME_SYNTAXES.html 
2. `non_canonical_partial_ord_impl` by clippy
    - Ord と PartialOrd の実装の一致
    - https://rust-lang.github.io/rust-clippy/master/index.html#non_canonical_partial_ord_impl 
3. `collapsible_if` by clippy
    - 二重の `if` を `&&` に展開
    - https://rust-lang.github.io/rust-clippy/master/index.html#collapsible_if